### PR TITLE
Change package name to line up with jaaslib.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-libjuju",
+  "name": "jujulib",
   "version": "0.1.0",
   "description": "Juju API client",
   "main": "api/client.js",


### PR DESCRIPTION
It's on npm so there isn't much point to have 'js' in the name. There is also the 'jaaslib' package already so this lines up the naming scheme.