### PR TITLE
Support bakery login and handle redirection errors from JAAS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ NODE_MODULES = node_modules
 PROJECT = js-libjuju
 SYSDEPS = build-essential python3-virtualenv tox
 
+# The generated admin facade is required by JS API client code and tests.
 ADMIN_FACADE = api/facades/admin-v3.js
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ NODE_MODULES = node_modules
 PROJECT = js-libjuju
 SYSDEPS = build-essential python3-virtualenv tox
 
+ADMIN_FACADE = api/facades/admin-v3.js
+
+
 .PHONY: all
 all: help
 
@@ -13,14 +16,12 @@ $(NODE_MODULES):
 	npm install
 	npm ls --depth=0
 
+$(ADMIN_FACADE):
+	$(MAKE) generate
+
 dev: $(DEVENV)
 
 dev-js: $(NODE_MODULES)
-
-.PHONY: generate
-generate: dev
-	rm -f api/facades/*.js
-	devenv/bin/generate schemas/schema.json
 
 .PHONY: dist
 dist: clean dev check
@@ -37,6 +38,12 @@ check-js: lint-js test-js
 clean:
 	rm -rf $(DEVENV) .tox dist *.egg-info
 	rm -rf $(NODE_MODULES)/ package-lock.json api/facades/*.js
+
+.PHONY: generate
+generate: dev
+	rm -f api/facades/*.js
+	devenv/bin/generate schemas/schema.json
+
 
 .PHONY: help
 help:
@@ -90,5 +97,5 @@ test: dev
 	$(DEVENV)/bin/python -m unittest discover . -v
 
 .PHONY: test-js
-test-js: dev-js
+test-js: dev-js $(ADMIN_FACADE)
 	npm t

--- a/api/client.js
+++ b/api/client.js
@@ -118,9 +118,8 @@ class Client {
     @param {Object} credentials An object with the user and password fields for
       userpass authentication or the macaroons field for bakery authentication.
       If an empty object is provided a full bakery discharge will be attempted
-      for logging in with macaroons. If the provided macaroons need discharge,
-      or no macaroons neither userpass are provided, the bakery instance
-      provided when connecting is used to obtain the third party discharges.
+      for logging in with macaroons. Any necessary third party discharges are
+      performed using the bakery instance originally provided to connect().
     @param {Function} callback Called when the login process completes, the
       callback receives an error and a connection object. If there are no
       errors, the connection can be used to send/receive messages to and from
@@ -210,7 +209,7 @@ class Client {
 
 // Define the redirect error returned by Juju, and the one returned by the API.
 const REDIRECTION_ERROR = 'redirection required';
-class RedirectionError{
+class RedirectionError {
   constructor(servers, caCert) {
     this.servers = servers;
     this.caCert = caCert;

--- a/api/client.js
+++ b/api/client.js
@@ -36,6 +36,10 @@
 
 'use strict';
 
+
+const Admin = require('./facades/admin-v3.js');
+
+
 /**
   Connect to the Juju controller or model at the given URL.
 
@@ -52,7 +56,9 @@
       for opening the connection and sending/receiving messages. Server side,
       require('websocket').w3cwebsocket can be used safely, as it implements the
       W3C browser native WebSocket API;
-    - adminFacadeVersion (default=3): the admin facade version;
+    - bakery (default: null): the bakery client to use when macaroon discharges
+      are required, in the case an external user is used to connect to Juju;
+      see <https://www.npmjs.com/package/macaroon-bakery>;
     - closeCallback: a callback to be called with the exit code when the
       connection is closed.
   @param {Function} callback Called when the connection is made, the callback
@@ -61,8 +67,8 @@
     class for information on how to use the client.
 */
 function connect(url, options={}, callback) {
-  if (!options.adminFacadeVersion) {
-    options.adminFacadeVersion = 3;
+  if (!options.bakery) {
+    options.bakery = null;
   }
   if (!options.closeCallback) {
     options.closeCallback = () => {};
@@ -102,7 +108,8 @@ class Client {
     // Instantiate the transport, used for sending messages to the server.
     this._transport = new Transport(ws, options.closeCallback, options.debug);
     this._facades = options.facades;
-    this._adminFacadeVersion = options.adminFacadeVersion;
+    this._bakery = options.bakery;
+    this._admin = new Admin(this._transport, {});
   }
 
   /**
@@ -110,31 +117,68 @@ class Client {
 
     @param {Object} credentials An object with the user and password fields for
       userpass authentication or the macaroons field for bakery authentication.
+      If an empty object is provided a full bakery discharge will be attempted
+      for logging in with macaroons. If the provided macaroons need discharge,
+      or no macaroons neither userpass are provided, the bakery instance
+      provided when connecting is used to obtain the third party discharges.
     @param {Function} callback Called when the login process completes, the
       callback receives an error and a connection object. If there are no
       errors, the connection can be used to send/receive messages to and from
       the Juju controller or model, and to get access to the available facades
       (through conn.facades). See the docstring for the Connection class for
-      information on how to use the connection instance.
+      information on how to use the connection instance. If an error is
+      returned, clients can check whether it's a redirection error as done by
+      JAAS when a new connection to the actual remote model is required. You
+      can check if that's the case using client.isRedirectionError(err). If it
+      is a redirection error, information about available servers is stored in
+      err.servers and err.caCert (if a certificate is required).
   */
   login(credentials, callback) {
-    // TODO(frankban): support bakery auth.
-    // TODO(frankban): support redirections when connecting to models.
-    const req = {
-      type: 'Admin',
-      request: 'Login',
-      params: {
-        'auth-tag': credentials.user,
-        credentials: credentials.password
-      },
-      version: this._adminFacadeVersion
+    const args = {
+      authTag: credentials.user,
+      credentials: credentials.password,
+      macaroons: credentials.macaroons
     };
-    this._transport.write(req, (err, resp) => {
+    this._admin.login(args, (err, result) => {
       if (err) {
-        callback(err, null);
+        if (err !== REDIRECTION_ERROR) {
+          // Authentication failed.
+          callback(err, null);
+          return;
+        }
+        // This is a model redirection error, so retrieve some info now.
+        this._admin.redirectInfo((err, result) => {
+          if (err) {
+            callback(err, null);
+            return;
+          }
+          callback(new RedirectionError(result.servers, result.caCert), null);
+        });
         return;
       }
-      const conn = new Connection(this._transport, this._facades, resp);
+
+      // Handle bakery discharge required responses.
+      if (result.dischargeRequired) {
+        if (!this._bakery) {
+          callback(
+            'macaroon discharge is required but no bakery instance provided',
+            null);
+          return;
+        }
+        const onSuccess = macaroons => {
+          // Send the login request again including the discharge macaroons.
+          credentials.macaroons = [macaroons];
+          this.login(credentials, callback);
+        };
+        const onFailure = err => {
+          callback('macaroon discharge failed: ' + err, null);
+        };
+        this._bakery.discharge(result.dischargeRequired, onSuccess, onFailure);
+        return;
+      }
+
+      // Authentication succeeded.
+      const conn = new Connection(this._transport, this._facades, result);
       callback(null, conn);
     });
   }
@@ -151,8 +195,27 @@ class Client {
     this._transport.close(callback);
   }
 
+  /**
+    Report whether the given error is a redirection error from Juju.
+
+    @param {Any} err The error returned by the login request.
+    @returns {Boolean} Whether the given error is a redirection error.
+  */
+  isRedirectionError(err) {
+    return err instanceof RedirectionError;
+  }
+
 }
 
+
+// Define the redirect error returned by Juju, and the one returned by the API.
+const REDIRECTION_ERROR = 'redirection required';
+class RedirectionError{
+  constructor(servers, caCert) {
+    this.servers = servers;
+    this.caCert = caCert;
+  }
+}
 
 /**
   A transport providing the ability of sending and receiving WebSocket messages
@@ -231,7 +294,11 @@ class Transport {
   close(callback) {
     const closeCallback = this._closeCallback;
     this._closeCallback = code => {
-      callback(code, closeCallback);
+      if (callback) {
+        callback(code, closeCallback);
+        return;
+      }
+      closeCallback(code);
     };
     this._ws.close();
   }
@@ -270,45 +337,35 @@ class Transport {
     instantiated, the matching available facades as declared by Juju are
     instantiated and access to them is provided via the facades property of the
     connection.
-  @param {Object} loginResp The response to the Juju login request. The response
-    includes information about the Juju server and available facades. This info
-    is made available via the info property of the connection instance.
+  @param {Object} loginResult The result to the Juju login request. It includes
+    information about the Juju server and available facades. This info is made
+    available via the info property of the connection instance.
 */
 class Connection {
 
-  constructor(transport, facades, loginResp) {
+  constructor(transport, facades, loginResult) {
     // Store the transport used for sending messages to Juju.
     this.transport = transport;
 
     // Populate info.
-    const userInfo = loginResp['user-info'] || {};
     this.info = {
-      controllerTag: loginResp['controller-tag'] || '',
-      modelTag: loginResp['model-tag'] || '',
-      serverVersion: loginResp['server-version'] || '',
-
-      user: {
-        displayName: userInfo['display-name'] || '',
-        identity: userInfo['identity'] || '',
-        lastConnection: userInfo['last-connection'] || '',
-        // TODO(frankban): expose an ACL object using access info, so that
-        // it's more user friendly.
-        controllerAccess: userInfo['controller-access'] || '',
-        modelAccess: userInfo['model-access'] || ''
-      },
-
+      controllerTag: loginResult.controllerTag,
+      modelTag: loginResult.modelTag,
+      publicDnsName: loginResult.publicDnsName,
+      serverVersion: loginResult.serverVersion,
+      servers: loginResult.servers,
+      user: loginResult.userInfo,
       getFacade: name => {
         return this.facades[name];
       }
     };
 
     // Handle facades.
-    const respFacades = loginResp.facades || [];
     const registered = facades.reduce((previous, current) => {
       previous[current.name] = current;
       return previous;
     }, {});
-    this.facades = respFacades.reduce((previous, current) => {
+    this.facades = loginResult.facades.reduce((previous, current) => {
       for (let i = current.versions.length-1; i >= 0; i--) {
         const className = current.name + 'V' + current.versions[i];
         const facadeClass = registered[className];
@@ -329,7 +386,7 @@ class Connection {
   Convert ThisString to thisString.
 
   @param {String} string A StringLikeThis.
-  @return {String} A stringLikeThis.
+  @returns {String} A stringLikeThis.
 */
 function uncapitalize(string) {
   return string.charAt(0).toLowerCase() + string.slice(1);

--- a/api/test-client.js
+++ b/api/test-client.js
@@ -35,35 +35,11 @@ tap.test('connect', t => {
         helpers.requestEqual(t, ws.lastRequest, {
           type: 'Admin',
           request: 'Login',
-          params: {'auth-tag': 'who', credentials: 'secret'},
+          params: {'auth-tag': 'who', credentials: 'secret', macaroons: []},
           version: 3
         });
         t.equal(err, 'bad wolf');
         t.equal(conn, null);
-        t.end();
-      });
-      // Reply to the login request.
-      ws.reply({error: 'bad wolf'});
-    });
-    // Open the WebSocket connection.
-    ws.open();
-  });
-
-  t.test('login with custom admin facade version', t => {
-    const options = {
-      wsclass: helpers.makeWSClass(instance => {
-        ws = instance;
-      }),
-      adminFacadeVersion: 42
-    };
-    jujulib.connect('wss://1.2.3.4', options, (err, juju) => {
-      juju.login({user: 'dalek', password: 'skaro'}, (err, conn) => {
-        helpers.requestEqual(t, ws.lastRequest, {
-          type: 'Admin',
-          request: 'Login',
-          params: {'auth-tag': 'dalek', credentials: 'skaro'},
-          version: 42
-        });
         t.end();
       });
       // Reply to the login request.
@@ -110,6 +86,7 @@ tap.test('connect', t => {
         'model-c36a62d0-a17a-484e-87bf-a09d1b403627');
       t.equal(conn.info.serverVersion, '2.42.47');
       t.deepEqual(conn.info.user, {
+        credentials: 'creds',
         displayName: 'who',
         identity: 'user-who@gallifrey',
         lastConnection: '2018-06-06T01:02:13Z',

--- a/api/test-helpers.js
+++ b/api/test-helpers.js
@@ -42,11 +42,12 @@ const loginResponse = {
   'model-tag': 'model-c36a62d0-a17a-484e-87bf-a09d1b403627',
   'server-version': '2.42.47',
   'user-info': {
-     'display-name': 'who',
-     identity: 'user-who@gallifrey',
-     'last-connection': '2018-06-06T01:02:13Z',
-     'controller-access': 'timelord',
-     'model-access': 'admin'
+    credentials: 'creds',
+    'display-name': 'who',
+    identity: 'user-who@gallifrey',
+    'last-connection': '2018-06-06T01:02:13Z',
+    'controller-access': 'timelord',
+    'model-access': 'admin'
   },
   facades: [{
     name: 'AllWatcher', versions: [0]

--- a/api/test-helpers.js
+++ b/api/test-helpers.js
@@ -133,6 +133,25 @@ class WebSocket {
 
 
 /**
+  Create and return a mock bakery instance.
+
+  @param {Boolean} succeeding Whether the simulated discharge succeeds.
+  @returns {Object} The mock bakery instance.
+*/
+function makeBakery(succeeding) {
+  return {
+    discharge: (macaroon, onSuccess, onFailure) => {
+      if (succeeding) {
+        onSuccess(['m1', 'm2']);
+        return;
+      }
+      onFailure('bad wolf');
+    }
+  };
+}
+
+
+/**
   Check that the two requests equal.
 
   @param {Object} t The test object.
@@ -149,6 +168,7 @@ function requestEqual(t, got, want) {
 
 module.exports = {
   BaseFacade: BaseFacade,
+  makeBakery: makeBakery,
   makeConnection: makeConnection,
   makeWSClass: makeWSClass,
   requestEqual: requestEqual

--- a/api/wrappers.js
+++ b/api/wrappers.js
@@ -30,9 +30,6 @@ function wrapAdmin(cls) {
     always returns an error because the Juju controller does not multiplex
     controllers.
 
-    This is overridden as the auto-generated version does not work with current
-    JAAS, as servers are returned slighty differently.
-
     @param {Function} callback Called when the response from Juju is available,
       the callback receives an error and the result. If there are no errors,
       the result is provided as an object like the following:
@@ -47,6 +44,9 @@ function wrapAdmin(cls) {
         }
   */
   cls.prototype.redirectInfo = function(callback) {
+    // This is overridden as the auto-generated version does not work with
+    // current JAAS, because the servers passed to the callback do not
+    // correspond to the ones declared in the API.
     // Prepare the request to the Juju API.
     const req = {
       type: 'Admin',

--- a/api/wrappers.js
+++ b/api/wrappers.js
@@ -18,10 +18,78 @@
 
 
 /**
+  Decorate the Admin facade class.
+
+  @param {Object} cls The auto-generated class.
+  @returns {Object} The decorated class.
+*/
+function wrapAdmin(cls) {
+
+  /**
+    RedirectInfo returns redirected host information for the model. In Juju it
+    always returns an error because the Juju controller does not multiplex
+    controllers.
+
+    This is overridden as the auto-generated version does not work with current
+    JAAS, as servers are returned slighty differently.
+
+    @param {Function} callback Called when the response from Juju is available,
+      the callback receives an error and the result. If there are no errors,
+      the result is provided as an object like the following:
+        {
+          servers: []{
+            value: string,
+            type: string,
+            scope: string,
+            port: string
+          },
+          caCert: string
+        }
+  */
+  cls.prototype.redirectInfo = function(callback) {
+    // Prepare the request to the Juju API.
+    const req = {
+      type: 'Admin',
+      request: 'RedirectInfo',
+      version: this.version,
+      params: {}
+    };
+    // Send the request to the server.
+    this._transport.write(req, (err, resp) => {
+      if (!callback) {
+        return;
+      }
+      if (err) {
+        callback(err, {});
+        return;
+      }
+      // Handle the response.
+      const servers = [];
+      resp.servers.forEach(srvs => {
+        srvs.forEach(srv => {
+          const server = {
+            value: srv.value,
+            port: srv.port,
+            type: srv.type,
+            scope: srv.scope,
+            url: uuid => `wss://${srv.value}:${srv.port}/model/${uuid}/api`
+          };
+          servers.push(server);
+        });
+      });
+      callback(null, {caCert: resp['ca-cert'], servers: servers});
+    });
+  };
+
+  return cls;
+}
+
+
+/**
   Decorate the AllWatcher facade class.
 
   @param {Object} cls The auto-generated class.
-  @return {Object} The decorated class.
+  @returns {Object} The decorated class.
 */
 function wrapAllWatcher(cls) {
 
@@ -93,6 +161,7 @@ function wrapAllWatcher(cls) {
       callback(err, {});
     });
   };
+
   return cls;
 }
 
@@ -101,7 +170,7 @@ function wrapAllWatcher(cls) {
   Decorate the Application facade class.
 
   @param {Object} cls The auto-generated class.
-  @return {Object} The decorated class.
+  @returns {Object} The decorated class.
 */
 function wrapApplication(cls) {
 
@@ -181,6 +250,7 @@ function wrapApplication(cls) {
       });
     });
   };
+
   return cls;
 }
 
@@ -189,7 +259,7 @@ function wrapApplication(cls) {
   Decorate the Client facade class.
 
   @param {Object} cls The auto-generated class.
-  @return {Object} The decorated class.
+  @returns {Object} The decorated class.
 */
 function wrapClient(cls) {
 
@@ -211,7 +281,7 @@ function wrapClient(cls) {
             removed: boolean (required)
           } (required)
         }
-    @return {Object} and handle that can be used to stop watching, via its stop
+    @returns {Object} and handle that can be used to stop watching, via its stop
       method which can be provided a callback receiving an error.
   */
   cls.prototype.watch = function(callback) {
@@ -256,6 +326,7 @@ function wrapClient(cls) {
       }
     };
   };
+
   return cls;
 }
 
@@ -264,7 +335,7 @@ function wrapClient(cls) {
   Decorate the Pinger facade class.
 
   @param {Object} cls The auto-generated class.
-  @return {Object} The decorated class.
+  @returns {Object} The decorated class.
 */
 function wrapPinger(cls) {
 
@@ -292,11 +363,13 @@ function wrapPinger(cls) {
       }
     };
   };
+
   return cls;
 }
 
 
 module.exports = {
+  wrapAdmin: wrapAdmin,
   wrapAllWatcher: wrapAllWatcher,
   wrapApplication: wrapApplication,
   wrapClient: wrapClient,

--- a/examples/deploy-with-wrapper.js
+++ b/examples/deploy-with-wrapper.js
@@ -21,13 +21,13 @@ const url = 'wss://35.240.22.136:17070/model/7ff7e1c9-f733-4eba-8d29-6c0946dc21d
 jujulib.connect(url, options, (err, juju) => {
   if (err) {
     console.log('cannot connect:', err);
-    return;
+    process.exit(1);
   }
 
   juju.login({user: 'user-admin', password: 'secret'}, (err, conn) => {
     if (err) {
       console.log('cannot login:', err);
-      return;
+      process.exit(1);
     }
 
     const application = conn.facades.application;
@@ -38,7 +38,7 @@ jujulib.connect(url, options, (err, juju) => {
     }, (err, result) => {
       if (err) {
         console.log('cannot deploy app:', err);
-        return;
+        process.exit(1);
       }
       console.log(result);
     });

--- a/examples/deploy.js
+++ b/examples/deploy.js
@@ -21,13 +21,13 @@ const url = 'wss://35.196.223.30:17070/model/bf716a6d-97cf-47b6-8b77-80e1890c092
 jujulib.connect(url, options, (err, juju) => {
   if (err) {
     console.log('cannot connect:', err);
-    return;
+    process.exit(1);
   }
 
   juju.login({user: 'user-admin', password: 'secret'}, (err, conn) => {
     if (err) {
       console.log('cannot login:', err);
-      return;
+      process.exit(1);
     }
 
     const application = conn.facades.application;
@@ -35,7 +35,7 @@ jujulib.connect(url, options, (err, juju) => {
     client.addCharm({url: 'cs:haproxy-43'}, err => {
       if (err) {
         console.log('cannot add charm:', err);
-        return;
+        process.exit(1);
       }
 
       application.deploy({
@@ -47,7 +47,7 @@ jujulib.connect(url, options, (err, juju) => {
       }, (err, result) => {
         if (err) {
           console.log('cannot deploy app:', err);
-          return;
+          process.exit(1);
         }
         console.log(result);
       });

--- a/examples/login-with-bakery.js
+++ b/examples/login-with-bakery.js
@@ -1,0 +1,94 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE.txt file for details.
+
+// Allow connecting endpoints using self-signed certs.
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+
+const WebSocket = require('websocket').w3cwebsocket;
+const bakery = require('../../bakeryjs/index.js');
+// Bakery uses btoa and MLHttpRequest.
+global.btoa = require('btoa');
+global.XMLHttpRequest = require('xhr2')
+
+const jujulib = require('../api/client.js');
+
+
+const options = {
+    debug: true,
+    facades: [require('../api/facades/model-manager-v4.js')],
+    wsclass: WebSocket,
+    bakery: new bakery.Bakery({
+        visitPage: resp => {
+            console.log('visit this URL to login:', resp.Info.VisitURL);
+        }
+    })
+};
+const url = 'wss://jimm.jujucharms.com/api';
+
+
+jujulib.connect(url, options, (err, juju) => {
+  if (err) {
+    console.log('cannot connect to controller:', err);
+    process.exit(1);
+  }
+  juju.login({}, (err, conn) => {
+    if (err) {
+      console.log('cannot login to controller:', err);
+      process.exit(1);
+    }
+    console.log('logged in to controller');
+
+    // List models.
+    const modelManager = conn.facades.modelManager;
+    modelManager.listModels({tag: conn.info.identity}, (err, result) => {
+      if (err) {
+        console.log('cannot list models:', err);
+        process.exit(1);
+      }
+
+      // Connect to the first model found.
+      const model = result.userModels[0].model;
+      console.log('connecting to model', model.name);
+      let modelURL = `wss://jimm.jujucharms.com/model/${model.uuid}/api`;
+      jujulib.connect(modelURL, options, (err, juju) => {
+        if (err) {
+          console.log('cannot connect to model:', err);
+          process.exit(1);
+        }
+        juju.login({}, (err, conn) => {
+          if (err) {
+            if (!juju.isRedirectionError(err)) {
+              console.log('cannot login to model:', err);
+              process.exit(1);
+            }
+            // Redirect to the real model.
+            juju.logout();
+
+            err.servers.forEach(srv => {
+              if (srv.type === 'hostname' && srv.scope === 'public') {
+                // This is a public server with a dns-name, connect to it.
+                const modelURL = srv.url(model.uuid);
+                jujulib.connect(modelURL, options, (err, juju) => {
+                  if (err) {
+                    console.log('cannot connect to model:', err);
+                    process.exit(1);
+                  }
+                  juju.login({}, (err, conn) => {
+                    if (err) {
+                      console.log('cannot login to model:', err);
+                      process.exit(1);
+                    }
+                    console.log('connected to model using', modelURL);
+                    process.exit(0);
+                  });
+                });
+              }
+            })
+          }
+          console.log('logged in to model without redirection');
+        });
+      });
+    });
+  });
+});

--- a/examples/login-with-bakery.js
+++ b/examples/login-with-bakery.js
@@ -6,7 +6,7 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 
 const WebSocket = require('websocket').w3cwebsocket;
-const bakery = require('../../bakeryjs/index.js');
+const bakery = require('macaroon-bakery');
 // Bakery uses btoa and MLHttpRequest.
 global.btoa = require('btoa');
 global.XMLHttpRequest = require('xhr2')

--- a/examples/ping.js
+++ b/examples/ping.js
@@ -20,20 +20,20 @@ const url = 'wss://35.196.223.30:17070/model/bf716a6d-97cf-47b6-8b77-80e1890c092
 jujulib.connect(url, options, (err, juju) => {
   if (err) {
     console.log('cannot connect:', err);
-    return;
+    process.exit(1);
   }
 
   juju.login({user: 'user-admin', password: 'secret'}, (err, conn) => {
     if (err) {
       console.log('cannot login:', err);
-      return;
+      process.exit(1);
     }
 
     const pinger = conn.facades.pinger;
     const handle = pinger.pingForever(1000, err => {
       if (err) {
         console.log('cannot ping:', err);
-        return;
+        process.exit(1);
       }
       console.log('pong');
     });

--- a/examples/watch.js
+++ b/examples/watch.js
@@ -21,20 +21,20 @@ const url = 'wss://35.196.223.30:17070/model/bf716a6d-97cf-47b6-8b77-80e1890c092
 jujulib.connect(url, options, (err, juju) => {
   if (err) {
     console.log('cannot connect:', err);
-    return;
+    process.exit(1);
   }
 
   juju.login({user: 'user-admin', password: 'secret'}, (err, conn) => {
     if (err) {
       console.log('cannot login:', err);
-      return;
+      process.exit(1);
     }
 
     const client = conn.facades.client;
     const handle = client.watch((err, result) => {
       if (err) {
         console.log('cannot watch model:', err);
-        return;
+        process.exit(1);
       }
       console.log(result);
     });

--- a/package.json
+++ b/package.json
@@ -23,9 +23,12 @@
   },
   "homepage": "https://github.com/juju/js-libjuju#readme",
   "devDependencies": {
+    "btoa": "^1.2.1",
     "eslint": "^4.19.1",
+    "macaroon-bakery": "^0.1.0",
     "tap": "^12.0.1",
-    "websocket": "^1.0.26"
+    "websocket": "^1.0.26",
+    "xhr2": "^0.1.4"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "btoa": "^1.2.1",
     "eslint": "^4.19.1",
-    "macaroon-bakery": "^0.1.0",
+    "macaroon-bakery": "^0.2.0",
     "tap": "^12.0.1",
     "websocket": "^1.0.26",
     "xhr2": "^0.1.4"

--- a/tests/data/bundle.js
+++ b/tests/data/bundle.js
@@ -81,18 +81,18 @@ class BundleV1 {
         result.changes[i].args = [];
         resp['changes'][i]['args'] = resp['changes'][i]['args'] || [];
         for (let i2 = 0; i2 < resp['changes'][i]['args'].length; i2++) {
-          result.changes[i].args[i2] = resp['changes'][i]['args'][i2] || undefined;
+          result.changes[i].args[i2] = resp['changes'][i]['args'][i2];
         }
         result.changes[i].requires = [];
         resp['changes'][i]['requires'] = resp['changes'][i]['requires'] || [];
         for (let i2 = 0; i2 < resp['changes'][i]['requires'].length; i2++) {
-          result.changes[i].requires[i2] = resp['changes'][i]['requires'][i2] || undefined;
+          result.changes[i].requires[i2] = resp['changes'][i]['requires'][i2];
         }
       }
       result.errors = [];
       resp['errors'] = resp['errors'] || [];
       for (let i = 0; i < resp['errors'].length; i++) {
-        result.errors[i] = resp['errors'][i] || undefined;
+        result.errors[i] = resp['errors'][i];
       }
       callback(null, result);
     });

--- a/tests/data/marshal.js
+++ b/tests/data/marshal.js
@@ -57,7 +57,7 @@ class MarshalV0 {
       resp['deltas'] = resp['deltas'] || [];
       for (let i = 0; i < resp['deltas'].length; i++) {
         // github.com/juju/juju/state/multiwatcher#Delta
-        result.deltas[i] = resp['deltas'][i] || undefined;
+        result.deltas[i] = resp['deltas'][i];
       }
       callback(null, result);
     });


### PR DESCRIPTION
Also:
- leverage the auto-generated admin facade for admin API calls;
- add support for checking whether a login error is a redirection error;
- add an example (login-with-bakery.js) for connecting to JAAS with macaroons, discharging them, logging in, listing models and then connecting to the first model after a redirection (hint: running this is a good QA exercise);
- implement a function wrapper for the admin facade, in order to address an issue in redirectInfo parameters;
- drop the `required` parameter used when generating facades from Python code: it was unreliable and also causing some weird side effects.