### PR TITLE
Fix API errors when handling nil pointers to structs.

### DIFF
--- a/api/client.js
+++ b/api/client.js
@@ -465,4 +465,4 @@ function uncapitalize(string) {
 }
 
 
-module.exports = {connect: connect, connectAndLogin: connectAndLogin};
+module.exports = {connect, connectAndLogin};

--- a/api/client.js
+++ b/api/client.js
@@ -95,6 +95,79 @@ function connect(url, options={}, callback) {
 
 
 /**
+  Connect to the Juju controller or model at the given URL and the authenticate
+  using the given credentials.
+
+  @param {String} url The WebSocket URL of the Juju controller or model.
+  @param {Object} credentials An object with the user and password fields for
+    userpass authentication or the macaroons field for bakery authentication.
+    If an empty object is provided a full bakery discharge will be attempted
+    for logging in with macaroons. Any necessary third party discharges are
+    performed using the bakery instance provided in the options (see below).
+  @param {Object} options Connections options, including:
+    - facades (default=[]): the list of facade classes to include in the API
+      connection object. Those classes are usually auto-generated and can be
+      found in the facades directory of the project. When multiple versions of
+      the same facade are included, the most recent version supported by the
+      server is made available as part of the connection object;
+    - debug (default=false): when enabled, all API messages are logged at debug
+      level;
+    - wsclass (default=W3C browser native WebSocket): the WebSocket class to use
+      for opening the connection and sending/receiving messages. Server side,
+      require('websocket').w3cwebsocket can be used safely, as it implements the
+      W3C browser native WebSocket API;
+    - bakery (default: null): the bakery client to use when macaroon discharges
+      are required, in the case an external user is used to connect to Juju;
+      see <https://www.npmjs.com/package/macaroon-bakery>;
+    - closeCallback: a callback to be called with the exit code when the
+      connection is closed.
+  @param {Function} callback Called when the login process completes, the
+    callback receives an error, a connection object and a logout function that
+    can be used to clos ethe connection. If there are no errors, the connection
+    can be used to send/receive messages to and from the Juju controller or
+    model, and to get access to the available facades (through conn.facades).
+    See the docstring for the Connection class for information on how to use
+    the connection instance. Redirection errors are automatically handled by
+    this function, so any error is a real connection problem.
+*/
+function connectAndLogin(url, credentials, options, callback) {
+  // Connect to Juju.
+  connect(url, options, (err, juju) => {
+    if (err) {
+      callback(err, null, null);
+      return;
+    }
+    // Authenticate.
+    juju.login(credentials, (err, conn) => {
+      if (!err) {
+        callback(null, conn, juju.logout.bind(juju));
+        return;
+      }
+      if (!juju.isRedirectionError(err)) {
+        callback(err, null, null);
+        return;
+      }
+      // Redirect to the real model.
+      juju.logout();
+      for (let i = 0; i < err.servers.length; i++) {
+        const srv = err.servers[i];
+        // TODO(frankban): we should really try to connect to all servers and
+        // just use the first connection available, without second guessing
+        // that the public hostname is reachable.
+        if (srv.type === 'hostname' && srv.scope === 'public') {
+          // This is a public server with a dns-name, connect to it.
+          connectAndLogin(srv.url(url), credentials, options, callback);
+          return;
+        }
+      }
+      callback(
+        new Error('cannot connect to model after redirection'), null, null);
+    });
+  });
+}
+
+
+/**
   A Juju API client allowing for logging in and get access to facades.
 
   @param {Object} ws The WebSocket instance already connected to a Juju
@@ -392,4 +465,4 @@ function uncapitalize(string) {
 }
 
 
-module.exports = {connect: connect};
+module.exports = {connect: connect, connectAndLogin: connectAndLogin};

--- a/api/test-helpers.js
+++ b/api/test-helpers.js
@@ -50,11 +50,15 @@ const loginResponse = {
     'model-access': 'admin'
   },
   facades: [{
+    name: 'AllModelWatcher', versions: [1]
+  }, {
     name: 'AllWatcher', versions: [0]
   }, {
     name: 'Application', versions: [7]
   }, {
     name: 'Client', versions: [2, 3]
+  }, {
+    name: 'Controller', versions: [3, 4, 5]
   }, {
     name: 'MyFacade', versions: [1, 7]
   }]
@@ -109,6 +113,7 @@ class WebSocket {
   }
 
   close(reason) {
+    this.readyState = 3;
     this.onclose({reason: reason});
   }
 

--- a/api/test-wrappers.js
+++ b/api/test-wrappers.js
@@ -10,6 +10,94 @@ const helpers = require('./test-helpers.js');
 const wrappers = require('./wrappers.js');
 
 
+tap.test('wrapAllModelWatcher', t => {
+  class AllModelWatcherV1 extends helpers.BaseFacade{};
+  const options = {facades: [wrappers.wrapAllModelWatcher(AllModelWatcherV1)]};
+
+  t.test('next success', t => {
+    helpers.makeConnection(t, options, (conn, ws) => {
+      const allModelWatcher = conn.facades.allModelWatcher;
+      const watcherId = 42;
+      allModelWatcher.next(watcherId, (err, result) => {
+        helpers.requestEqual(t, ws.lastRequest, {
+          type: 'AllModelWatcher',
+          request: 'Next',
+          version: 1
+        });
+        t.equal(ws.lastRequest.id, watcherId);
+        t.equal(err, null);
+        t.deepEqual(result, {
+          deltas: [[
+            'model', 'change', {name: 'default'}
+          ], [
+            'machine', 'change', {name: 'machine2'}
+          ]]
+        });
+        t.end();
+      });
+      // Reply to the next request.
+      ws.reply({response: {
+        deltas: [[
+          'model', 'change', {name: 'default'}
+        ], [
+          'machine', 'change', {name: 'machine2'}
+        ]]
+      }});
+    });
+  });
+
+  t.test('next failure', t => {
+    helpers.makeConnection(t, options, (conn, ws) => {
+      const allModelWatcher = conn.facades.allModelWatcher;
+      const watcherId = 42;
+      allModelWatcher.next(watcherId, (err, result) => {
+        t.equal(err, 'bad wolf');
+        t.deepEqual(result, {});
+        t.end();
+      });
+      // Reply to the next request.
+      ws.reply({error: 'bad wolf'});
+    });
+  });
+
+  t.test('stop success', t => {
+    helpers.makeConnection(t, options, (conn, ws) => {
+      const allModelWatcher = conn.facades.allModelWatcher;
+      const watcherId = 42;
+      allModelWatcher.stop(watcherId, (err, result) => {
+        helpers.requestEqual(t, ws.lastRequest, {
+          type: 'AllModelWatcher',
+          request: 'Stop',
+          version: 1
+        });
+        t.equal(ws.lastRequest.id, watcherId);
+        t.equal(err, null);
+        t.deepEqual(result, {});
+        t.end();
+      });
+      // Reply to the next request.
+      ws.reply({response: {}});
+    });
+  });
+
+  t.test('stop failure', t => {
+    helpers.makeConnection(t, options, (conn, ws) => {
+      const allModelWatcher = conn.facades.allModelWatcher;
+      const watcherId = 42;
+      allModelWatcher.stop(watcherId, (err, result) => {
+        t.equal(err, 'bad wolf');
+        t.deepEqual(result, {});
+        t.end();
+      });
+      // Reply to the next request.
+      ws.reply({error: 'bad wolf'});
+    });
+  });
+
+  t.end();
+});
+
+
 tap.test('wrapAllWatcher', t => {
   class AllWatcherV0 extends helpers.BaseFacade{};
   const options = {facades: [wrappers.wrapAllWatcher(AllWatcherV0)]};
@@ -326,6 +414,192 @@ tap.test('wrapClient', t => {
     helpers.makeConnection(t, options, (conn, ws) => {
       const client = conn.facades.client;
       client.watch((err, result) => {
+        t.equal(err, 'bad wolf');
+        t.deepEqual(result, {});
+        t.end();
+      });
+      // Reply to the next request.
+      ws.reply({error: 'bad wolf'});
+    });
+  });
+
+  t.test('addMachine success', t => {
+    let gotArgs = null;
+    class ClientV3 extends helpers.BaseFacade{
+      addMachines(args, callback) {
+        gotArgs = args;
+        callback(null, {machines: [{machine: 42}]});
+      }
+    };
+    const options = {facades: [wrappers.wrapClient(ClientV3)]};
+    helpers.makeConnection(t, options, (conn, ws) => {
+      const client = conn.facades.client;
+      client.addMachine({
+        arch: 'amd64',
+        constraints: {cores: 8},
+        jobs: ['job1', 'job2'],
+        parentId: 2,
+        series: 'bionic'
+      }, (err, result) => {
+        t.equal(err, null);
+        t.deepEqual(result, {machine: 42});
+        t.deepEqual(gotArgs, {params: [{
+          arch: 'amd64',
+          constraints: {cores: 8},
+          jobs: ['job1', 'job2'],
+          parentId: 2,
+          series: 'bionic'
+        }]});
+        t.end();
+      });
+    });
+  });
+
+  t.test('addMachine success without jobs', t => {
+    let gotArgs = null;
+    class ClientV3 extends helpers.BaseFacade{
+      addMachines(args, callback) {
+        gotArgs = args;
+        callback(null, {machines: [{machine: 42}]});
+      }
+    };
+    const options = {facades: [wrappers.wrapClient(ClientV3)]};
+    helpers.makeConnection(t, options, (conn, ws) => {
+      const client = conn.facades.client;
+      client.addMachine({series: 'cosmic'}, (err, result) => {
+        t.deepEqual(gotArgs, {params: [{
+          jobs: ['JobHostUnits'],
+          series: 'cosmic'
+        }]});
+        t.end();
+      });
+    });
+  });
+
+  t.test('addMachine failure', t => {
+    class ClientV3 extends helpers.BaseFacade{
+      addMachines(args, callback) {
+        callback('bad wolf', {});
+      }
+    };
+    const options = {facades: [wrappers.wrapClient(ClientV3)]};
+    helpers.makeConnection(t, options, (conn, ws) => {
+      const client = conn.facades.client;
+      client.addMachine({series: 'bionic'}, (err, result) => {
+        t.equal(err, 'bad wolf');
+        t.deepEqual(result, {});
+        t.end();
+      });
+    });
+  });
+
+  t.end();
+});
+
+
+tap.test('wrapController', t => {
+
+  t.test('watch success', t => {
+    class ControllerV4 extends helpers.BaseFacade{
+      watchAllModels(callback) {
+        callback(null, {watcherId: 47});
+      }
+    };
+    class AllModelWatcherV1 extends helpers.BaseFacade{};
+    const options = {facades: [
+      wrappers.wrapController(ControllerV4),
+      wrappers.wrapAllModelWatcher(AllModelWatcherV1)
+    ]};
+    helpers.makeConnection(t, options, (conn, ws) => {
+      const controller = conn.facades.controller;
+      let callCount = 0;
+      controller.watch((err, result) => {
+        t.equal(err, null);
+        callCount += 1;
+        switch(callCount) {
+          case 1:
+            t.deepEqual(result, {
+              deltas: [[
+                'model', 'change', {name: 'default'}
+              ], [
+                'machine', 'change', {name: 'machine2'}
+              ]]
+            });
+            break;
+          case 2:
+            t.deepEqual(result, {
+              deltas: [['app', 'change', {name: 'app2'}]]
+            });
+            t.end();
+            break;
+        }
+      });
+      // Reply to next requests.
+      ws.reply({response: {
+        deltas: [[
+          'model', 'change', {name: 'default'}
+        ], [
+          'machine', 'change', {name: 'machine2'}
+        ]]
+      }});
+      ws.reply({response: {
+        deltas: [['app', 'change', {name: 'app2'}]]
+      }});
+    });
+  });
+
+  t.test('watch failure allWatcher not found', t => {
+    class ControllerV4 extends helpers.BaseFacade{};
+    const options = {facades: [
+      wrappers.wrapController(ControllerV4),
+    ]};
+    helpers.makeConnection(t, options, (conn, ws) => {
+      const controller = conn.facades.controller;
+      controller.watch((err, result) => {
+        t.equal(err, 'watch requires the allModelWatcher facade to be loaded');
+        t.deepEqual(result, {});
+        // Only the login request has been made, no other requests.
+        t.deepEqual(ws.requests.length, 1);
+        t.end();
+      });
+    });
+  });
+
+  t.test('watch failure on initial watch request', t => {
+    class ControllerV4 extends helpers.BaseFacade{
+      watchAllModels(callback) {
+        callback('bad wolf', {});
+      }
+    };
+    class AllModelWatcherV1 extends helpers.BaseFacade{};
+    const options = {facades: [
+      wrappers.wrapController(ControllerV4),
+      wrappers.wrapAllModelWatcher(AllModelWatcherV1)
+    ]};
+    helpers.makeConnection(t, options, (conn, ws) => {
+      const controller = conn.facades.controller;
+      controller.watch((err, result) => {
+        t.equal(err, 'bad wolf');
+        t.deepEqual(result, {});
+        t.end();
+      });
+    });
+  });
+
+  t.test('watch failure on next request', t => {
+    class ControllerV5 extends helpers.BaseFacade{
+      watchAllModels(callback) {
+        callback(null, {watcherId: 47});
+      }
+    };
+    class AllModelWatcherV1 extends helpers.BaseFacade{};
+    const options = {facades: [
+      wrappers.wrapController(ControllerV5),
+      wrappers.wrapAllModelWatcher(AllModelWatcherV1)
+    ]};
+    helpers.makeConnection(t, options, (conn, ws) => {
+      const controller = conn.facades.controller;
+      controller.watch((err, result) => {
         t.equal(err, 'bad wolf');
         t.deepEqual(result, {});
         t.end();

--- a/api/wrappers.js
+++ b/api/wrappers.js
@@ -443,7 +443,7 @@ function wrapClient(cls) {
         {
           deltas: []anything
         }
-    @returns {Object} An handle that can be used to stop watching, via its stop
+    @returns {Object} A handle that can be used to stop watching, via its stop
       method which can be provided a callback receiving an error.
   */
  cls.prototype.watch = function(callback) {
@@ -514,7 +514,7 @@ function wrapController(cls) {
         {
           deltas: []anything
         }
-    @returns {Object} An handle that can be used to stop watching, via its stop
+    @returns {Object} A handle that can be used to stop watching, via its stop
       method which can be provided a callback receiving an error.
   */
   cls.prototype.watch = function(callback) {
@@ -602,11 +602,11 @@ function wrapPinger(cls) {
 
 
 module.exports = {
-  wrapAdmin: wrapAdmin,
-  wrapAllModelWatcher: wrapAllModelWatcher,
-  wrapAllWatcher: wrapAllWatcher,
-  wrapApplication: wrapApplication,
-  wrapClient: wrapClient,
-  wrapController: wrapController,
-  wrapPinger: wrapPinger
+  wrapAdmin,
+  wrapAllModelWatcher,
+  wrapAllWatcher,
+  wrapApplication,
+  wrapClient,
+  wrapController,
+  wrapPinger
 };

--- a/api/wrappers.js
+++ b/api/wrappers.js
@@ -72,12 +72,100 @@ function wrapAdmin(cls) {
             port: srv.port,
             type: srv.type,
             scope: srv.scope,
-            url: uuid => `wss://${srv.value}:${srv.port}/model/${uuid}/api`
+            url: uuidOrURL => {
+              let uuid = uuidOrURL;
+              if (uuid.startsWith('wss://') || uuid.startsWith('ws://')) {
+                const parts = uuid.split('/');
+                uuid = parts[parts.length - 2];
+              }
+              return `wss://${srv.value}:${srv.port}/model/${uuid}/api`;
+            }
           };
           servers.push(server);
         });
       });
       callback(null, {caCert: resp['ca-cert'], servers: servers});
+    });
+  };
+
+  return cls;
+}
+
+
+/**
+  Decorate the AllModelWatcher facade class.
+
+  @param {Object} cls The auto-generated class.
+  @returns {Object} The decorated class.
+*/
+function wrapAllModelWatcher(cls) {
+
+  /**
+    Ask for next watcher messages corresponding to changes in the models.
+
+    This method is overridden as the auto-generated one does not include the
+    watcherId parameter, as a result of the peculiarity of the call, which does
+    not assume the id to be in parameters, but as a top level field.
+
+    @param {String} watcherId The id of the currently used watcher. The id is
+      retrieved by calling the Controller.watchAllModels API call.
+    @param {Function} callback Called when the next messages arrive, the
+      callback receives an error and the changes. If there are no errors,
+      changes are provided as an object like the following:
+        {
+          deltas: []anything
+        }
+  */
+  cls.prototype.next = function(watcherId, callback) {
+    // Prepare the request to the Juju API.
+    const req = {
+      type: 'AllModelWatcher',
+      request: 'Next',
+      version: this.version,
+      id: watcherId
+    };
+    // Send the request to the server.
+    this._transport.write(req, (err, resp) => {
+      if (!callback) {
+        return;
+      }
+      if (err) {
+        callback(err, {});
+        return;
+      }
+      // Handle the response.
+      resp = resp || {};
+      const result = {deltas: resp.deltas || []};
+      callback(null, result);
+    });
+  };
+
+  /**
+    Stop watching all models.
+
+    This method is overridden as the auto-generated one does not include the
+    watcherId parameter, as a result of the peculiarity of the call, which does
+    not assume the id to be in parameters, but as a top level field.
+
+    @param {String} watcherId The id of the currently used watcher. The id is
+      retrieved by calling the Controller.watchAllModels API call.
+    @param {Function} callback Called after the watcher has been stopped, the
+      callback receives an error.
+  */
+  cls.prototype.stop = function(watcherId, callback) {
+    // Prepare the request to the Juju API.
+    const req = {
+      type: 'AllModelWatcher',
+      request: 'Stop',
+      version: this.version,
+      id: watcherId
+    };
+    // Send the request to the server.
+    this._transport.write(req, (err, resp) => {
+      if (!callback) {
+        return;
+      }
+      callback(err, {});
     });
   };
 
@@ -264,6 +352,85 @@ function wrapApplication(cls) {
 function wrapClient(cls) {
 
   /**
+    Add a new machine to the model.
+
+    @param {Object} args Arguments fot creating a machine, like the following:
+        {
+          series: string,
+          constraints: {
+            arch: string,
+            container: string,
+            cores: int,
+            cpuPower: int,
+            mem: int,
+            rootDisk: int,
+            tags: []string,
+            instanceType: string,
+            spaces: []string,
+            virtType: string
+          },
+          jobs: []string,
+          disks: []{
+            pool: string,
+            size: int,
+            count: int
+          },
+          placement: {
+            scope: string,
+            directive: string
+          },
+          parentId: string,
+          containerType: string,
+          instanceId: string,
+          nonce: string,
+          hardwareCharacteristics: {
+            arch: string,
+            mem: int,
+            rootDisk: int,
+            cpuCores: int,
+            cpuPower: int,
+            tags: []string,
+            availabilityZone: string
+          },
+          addresses: []{
+            value: string,
+            type: string,
+            scope: string,
+            spaceName: string
+          }
+        }
+    @param {Function} callback Called when the response from Juju is available,
+      the callback receives an error and the result. If there are no errors,
+      the result is provided as an object like the following:
+        {
+          machine: string,
+          error: {
+            message: string,
+            code: string,
+            info: {
+              macaroon: anything,
+              macaroonPath: string
+            }
+          }
+        }
+  */
+  cls.prototype.addMachine = function(args, callback) {
+    if (!args.jobs) {
+      args.jobs = ['JobHostUnits'];
+    }
+    this.addMachines({params: [args]}, (err, result) => {
+      if (!callback) {
+        return;
+      }
+      if (err) {
+        callback(err, {});
+        return;
+      }
+      callback(null, result.machines[0]);
+    });
+  };
+
+  /**
     Watch changes in the current model, and call the provided callback every
     time changes arrive.
 
@@ -274,24 +441,90 @@ function wrapClient(cls) {
       callback receives an error and a the changes. If there are no errors,
       changes are provided as an object like the following:
         {
-          deltas: []{
-            entity: {
-
-            } (required),
-            removed: boolean (required)
-          } (required)
+          deltas: []anything
         }
-    @returns {Object} and handle that can be used to stop watching, via its stop
+    @returns {Object} An handle that can be used to stop watching, via its stop
+      method which can be provided a callback receiving an error.
+  */
+ cls.prototype.watch = function(callback) {
+  if (!callback) {
+    callback = () => {};
+  }
+  // Check that the AllWatcher facade is loaded, as we will use it.
+  const allWatcher = this._info.getFacade('allWatcher');
+  if (!allWatcher) {
+    callback('watch requires the allWatcher facade to be loaded', {});
+    return;
+  }
+  let watcherId;
+  // Define a function to repeatedly ask for next changes.
+  const next = callback => {
+    if (!watcherId) {
+      return;
+    }
+    allWatcher.next(watcherId, (err, result) => {
+      callback(err, result);
+      next(callback);
+    });
+  };
+  // Start watching.
+  this.watchAll((err, result) => {
+    if (err) {
+      callback(err, {});
+      return;
+    }
+    watcherId = result.watcherId;
+    next(callback);
+  });
+  // Return the handle allowing for stopping the watcher.
+  return {
+    stop: callback => {
+      if (watcherId === undefined) {
+        callback('watcher is not running', {});
+        return;
+      }
+      allWatcher.stop(watcherId, callback);
+      watcherId = undefined;
+    }
+  };
+};
+
+  return cls;
+}
+
+
+/**
+  Decorate the Controller facade class.
+
+  @param {Object} cls The auto-generated class.
+  @returns {Object} The decorated class.
+*/
+function wrapController(cls) {
+
+  /**
+    Watch changes in the all models on this controller, and call the provided
+    callback every time changes arrive.
+
+    This method requires the AllModelWatcher facade to be loaded and available
+    to the client.
+
+    @param {Function} callback Called every time changes arrive from Juju, the
+      callback receives an error and a the changes. If there are no errors,
+      changes are provided as an object like the following:
+        {
+          deltas: []anything
+        }
+    @returns {Object} An handle that can be used to stop watching, via its stop
       method which can be provided a callback receiving an error.
   */
   cls.prototype.watch = function(callback) {
     if (!callback) {
       callback = () => {};
     }
-    // Check that the AllWatcher facade is loaded, as we will use it.
-    const allWatcher = this._info.getFacade('allWatcher');
-    if (!allWatcher) {
-      callback('watch requires the allWatcher facade to be loaded', {});
+    // Check that the AllModelWatcher facade is loaded, as we will use it.
+    const allModelWatcher = this._info.getFacade('allModelWatcher');
+    if (!allModelWatcher) {
+      callback('watch requires the allModelWatcher facade to be loaded', {});
       return;
     }
     let watcherId;
@@ -300,13 +533,13 @@ function wrapClient(cls) {
       if (!watcherId) {
         return;
       }
-      allWatcher.next(watcherId, (err, result) => {
+      allModelWatcher.next(watcherId, (err, result) => {
         callback(err, result);
         next(callback);
       });
     };
     // Start watching.
-    this.watchAll((err, result) => {
+    this.watchAllModels((err, result) => {
       if (err) {
         callback(err, {});
         return;
@@ -321,7 +554,7 @@ function wrapClient(cls) {
           callback('watcher is not running', {});
           return;
         }
-        allWatcher.stop(watcherId, callback);
+        allModelWatcher.stop(watcherId, callback);
         watcherId = undefined;
       }
     };
@@ -370,8 +603,10 @@ function wrapPinger(cls) {
 
 module.exports = {
   wrapAdmin: wrapAdmin,
+  wrapAllModelWatcher: wrapAllModelWatcher,
   wrapAllWatcher: wrapAllWatcher,
   wrapApplication: wrapApplication,
   wrapClient: wrapClient,
+  wrapController: wrapController,
   wrapPinger: wrapPinger
 };

--- a/examples/add-machine.js
+++ b/examples/add-machine.js
@@ -1,0 +1,41 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE.txt file for details.
+
+const WebSocket = require('websocket').w3cwebsocket;
+const bakery = require('macaroon-bakery');
+// Bakery uses btoa and MLHttpRequest.
+global.btoa = require('btoa');
+global.XMLHttpRequest = require('xhr2')
+
+const jujulib = require('../api/client.js');
+
+
+const url = 'wss://jimm.jujucharms.com:443/model/9f367e7c-8601-4d55-85e3-0fd8d7867287/api';
+const credentials = {};
+const options = {
+  debug: true,
+  facades: [require('../api/facades/client-v1.js')],
+  wsclass: WebSocket,
+  bakery: new bakery.Bakery({
+    visitPage: resp => {
+      console.log('visit this URL to login:', resp.Info.VisitURL);
+    }
+  })
+};
+
+
+jujulib.connectAndLogin(url, credentials, options, (err, conn, logout) => {
+  if (err) {
+    console.log('cannot connect:', err);
+    process.exit(1);
+  }
+  // Add a single bionic machine.
+  const client = conn.facades.client;
+  client.addMachine({series: 'bionic'}, (err, result) => {
+    if (err) {
+      console.log('cannot add machine:', err);
+      process.exit(1);
+    }
+    console.log('machine added:', result);
+  });
+});

--- a/examples/deploy-with-wrapper.js
+++ b/examples/deploy-with-wrapper.js
@@ -10,12 +10,12 @@ const WebSocket = require('websocket').w3cwebsocket;
 const jujulib = require('../api/client.js');
 
 
+const url = 'wss://130.211.62.123:17070/model/ae6e92c5-cce7-4943-8913-72514a485ea8/api';
 const facades = [
   require('../api/facades/application-v5.js'),
   require('../api/facades/client-v1.js')
 ];
 const options = {debug: true, facades: facades, wsclass: WebSocket};
-const url = 'wss://35.240.22.136:17070/model/7ff7e1c9-f733-4eba-8d29-6c0946dc21d0/api';
 
 
 jujulib.connect(url, options, (err, juju) => {

--- a/examples/deploy.js
+++ b/examples/deploy.js
@@ -10,12 +10,12 @@ const WebSocket = require('websocket').w3cwebsocket;
 const jujulib = require('../api/client.js');
 
 
+const url = 'wss://130.211.62.123:17070/model/ae6e92c5-cce7-4943-8913-72514a485ea8/api';
 const facades = [
   require('../api/facades/application-v5.js'),
   require('../api/facades/client-v1.js')
 ];
 const options = {debug: true, facades: facades, wsclass: WebSocket};
-const url = 'wss://35.196.223.30:17070/model/bf716a6d-97cf-47b6-8b77-80e1890c0920/api';
 
 
 jujulib.connect(url, options, (err, juju) => {

--- a/examples/login-with-bakery.js
+++ b/examples/login-with-bakery.js
@@ -14,6 +14,7 @@ global.XMLHttpRequest = require('xhr2')
 const jujulib = require('../api/client.js');
 
 
+const url = 'wss://jimm.jujucharms.com/api';
 const options = {
     debug: true,
     facades: [require('../api/facades/model-manager-v4.js')],
@@ -24,7 +25,6 @@ const options = {
         }
     })
 };
-const url = 'wss://jimm.jujucharms.com/api';
 
 
 jujulib.connect(url, options, (err, juju) => {

--- a/examples/ping.js
+++ b/examples/ping.js
@@ -10,11 +10,9 @@ const WebSocket = require('websocket').w3cwebsocket;
 const jujulib = require('../api/client.js');
 
 
-const facades = [
-  require('../api/facades/pinger-v1.js')
-];
+const url = 'wss://130.211.62.123:17070/model/ae6e92c5-cce7-4943-8913-72514a485ea8/api';
+const facades = [require('../api/facades/pinger-v1.js')];
 const options = {debug: true, facades: facades, wsclass: WebSocket};
-const url = 'wss://35.196.223.30:17070/model/bf716a6d-97cf-47b6-8b77-80e1890c0920/api';
 
 
 jujulib.connect(url, options, (err, juju) => {

--- a/generator/_code.py
+++ b/generator/_code.py
@@ -202,19 +202,25 @@ class Struct:
         return '{' + text + '}'
 
     def generate_request(self, key, value):
-        parts = [key + ' = {};', value + ' = ' + value + ' || {};']
-        parts.extend(t.generate_request(key, value) for t in self.types)
+        parts = ['if ({}) {{'.format(value), _indent(1, key + ' = {};')]
+        parts.extend(
+            _indent(1, t.generate_request(key, value)) for t in self.types)
+        parts.append('}')
         return '\n'.join(parts)
 
     def generate_response(self, key, value):
-        parts = [key + ' = {};', value + ' = ' + value + ' || {};']
-        type_parts = [t.generate_response(key, value) for t in self.types]
+        # key = result
+        # value = resp
+        parts = ['if ({}) {{'.format(value), _indent(1, key + ' = {};')]
+        type_parts = [
+            _indent(1, t.generate_response(key, value)) for t in self.types]
         if type_parts:
             parts.extend(type_parts)
         else:
-            # This is an opaque object not decsribed by the schema, so just
+            # This is an opaque object not described by the schema, so just
             # copy it.
-            parts.append(key + ' = ' + value + ';')
+            parts.append(_indent(1, key + ' = ' + value + ';'))
+        parts.append('}')
         return '\n'.join(parts)
 
 

--- a/tests/data/annotations.js
+++ b/tests/data/annotations.js
@@ -52,15 +52,17 @@ class AnnotationsV2 {
     // Prepare request parameters.
     let params;
     // github.com/juju/juju/apiserver/params#Entities
-    params = {};
-    args = args || {};
-    params['entities'] = [];
-    args.entities = args.entities || [];
-    for (let i = 0; i < args.entities.length; i++) {
-      // github.com/juju/juju/apiserver/params#Entity
-      params['entities'][i] = {};
-      args.entities[i] = args.entities[i] || {};
-      params['entities'][i]['tag'] = args.entities[i].tag;
+    if (args) {
+      params = {};
+      params['entities'] = [];
+      args.entities = args.entities || [];
+      for (let i = 0; i < args.entities.length; i++) {
+        // github.com/juju/juju/apiserver/params#Entity
+        if (args.entities[i]) {
+          params['entities'][i] = {};
+          params['entities'][i]['tag'] = args.entities[i].tag;
+        }
+      }
     }
     // Prepare the request to the Juju API.
     const req = {
@@ -81,28 +83,32 @@ class AnnotationsV2 {
       // Handle the response.
       let result;
       // github.com/juju/juju/apiserver/params#AnnotationsGetResults
-      result = {};
-      resp = resp || {};
-      result.results = [];
-      resp['results'] = resp['results'] || [];
-      for (let i = 0; i < resp['results'].length; i++) {
-        // github.com/juju/juju/apiserver/params#AnnotationsGetResult
-        result.results[i] = {};
-        resp['results'][i] = resp['results'][i] || {};
-        result.results[i].entity = resp['results'][i]['entity'];
-        result.results[i].annotations = {};
-        resp['results'][i]['annotations'] = resp['results'][i]['annotations'] || {};
-        for (let k in resp['results'][i]['annotations']) {
-          result.results[i].annotations[k] = resp['results'][i]['annotations'][k];
+      if (resp) {
+        result = {};
+        result.results = [];
+        resp['results'] = resp['results'] || [];
+        for (let i = 0; i < resp['results'].length; i++) {
+          // github.com/juju/juju/apiserver/params#AnnotationsGetResult
+          if (resp['results'][i]) {
+            result.results[i] = {};
+            result.results[i].entity = resp['results'][i]['entity'];
+            result.results[i].annotations = {};
+            resp['results'][i]['annotations'] = resp['results'][i]['annotations'] || {};
+            for (let k in resp['results'][i]['annotations']) {
+              result.results[i].annotations[k] = resp['results'][i]['annotations'][k];
+            }
+            // github.com/juju/juju/apiserver/params#ErrorResult
+            if (resp['results'][i]['error']) {
+              result.results[i].error = {};
+              // github.com/juju/juju/apiserver/params#Error
+              if (resp['results'][i]['error']['error']) {
+                result.results[i].error.error = {};
+                result.results[i].error.error.message = resp['results'][i]['error']['error']['message'];
+                result.results[i].error.error.code = resp['results'][i]['error']['error']['code'];
+              }
+            }
+          }
         }
-        // github.com/juju/juju/apiserver/params#ErrorResult
-        result.results[i].error = {};
-        resp['results'][i]['error'] = resp['results'][i]['error'] || {};
-        // github.com/juju/juju/apiserver/params#Error
-        result.results[i].error.error = {};
-        resp['results'][i]['error']['error'] = resp['results'][i]['error']['error'] || {};
-        result.results[i].error.error.message = resp['results'][i]['error']['error']['message'];
-        result.results[i].error.error.code = resp['results'][i]['error']['error']['code'];
       }
       callback(null, result);
     });
@@ -135,19 +141,21 @@ class AnnotationsV2 {
     // Prepare request parameters.
     let params;
     // github.com/juju/juju/apiserver/params#AnnotationsSet
-    params = {};
-    args = args || {};
-    params['annotations'] = [];
-    args.annotations = args.annotations || [];
-    for (let i = 0; i < args.annotations.length; i++) {
-      // github.com/juju/juju/apiserver/params#EntityAnnotations
-      params['annotations'][i] = {};
-      args.annotations[i] = args.annotations[i] || {};
-      params['annotations'][i]['entity'] = args.annotations[i].entity;
-      params['annotations'][i]['annotations'] = {};
-      args.annotations[i].annotations = args.annotations[i].annotations || {};
-      for (let k in args.annotations[i].annotations) {
-        params['annotations'][i]['annotations'][k] = args.annotations[i].annotations[k];
+    if (args) {
+      params = {};
+      params['annotations'] = [];
+      args.annotations = args.annotations || [];
+      for (let i = 0; i < args.annotations.length; i++) {
+        // github.com/juju/juju/apiserver/params#EntityAnnotations
+        if (args.annotations[i]) {
+          params['annotations'][i] = {};
+          params['annotations'][i]['entity'] = args.annotations[i].entity;
+          params['annotations'][i]['annotations'] = {};
+          args.annotations[i].annotations = args.annotations[i].annotations || {};
+          for (let k in args.annotations[i].annotations) {
+            params['annotations'][i]['annotations'][k] = args.annotations[i].annotations[k];
+          }
+        }
       }
     }
     // Prepare the request to the Juju API.
@@ -169,19 +177,22 @@ class AnnotationsV2 {
       // Handle the response.
       let result;
       // github.com/juju/juju/apiserver/params#ErrorResults
-      result = {};
-      resp = resp || {};
-      result.results = [];
-      resp['results'] = resp['results'] || [];
-      for (let i = 0; i < resp['results'].length; i++) {
-        // github.com/juju/juju/apiserver/params#ErrorResult
-        result.results[i] = {};
-        resp['results'][i] = resp['results'][i] || {};
-        // github.com/juju/juju/apiserver/params#Error
-        result.results[i].error = {};
-        resp['results'][i]['error'] = resp['results'][i]['error'] || {};
-        result.results[i].error.message = resp['results'][i]['error']['message'];
-        result.results[i].error.code = resp['results'][i]['error']['code'];
+      if (resp) {
+        result = {};
+        result.results = [];
+        resp['results'] = resp['results'] || [];
+        for (let i = 0; i < resp['results'].length; i++) {
+          // github.com/juju/juju/apiserver/params#ErrorResult
+          if (resp['results'][i]) {
+            result.results[i] = {};
+            // github.com/juju/juju/apiserver/params#Error
+            if (resp['results'][i]['error']) {
+              result.results[i].error = {};
+              result.results[i].error.message = resp['results'][i]['error']['message'];
+              result.results[i].error.code = resp['results'][i]['error']['code'];
+            }
+          }
+        }
       }
       callback(null, result);
     });

--- a/tests/data/bundle.js
+++ b/tests/data/bundle.js
@@ -46,9 +46,10 @@ class BundleV1 {
     // Prepare request parameters.
     let params;
     // github.com/juju/juju/apiserver/params#BundleChangesParams
-    params = {};
-    args = args || {};
-    params['yaml'] = args.yaml;
+    if (args) {
+      params = {};
+      params['yaml'] = args.yaml;
+    }
     // Prepare the request to the Juju API.
     const req = {
       type: 'Bundle',
@@ -68,31 +69,33 @@ class BundleV1 {
       // Handle the response.
       let result;
       // github.com/juju/juju/apiserver/params#BundleChangesResults
-      result = {};
-      resp = resp || {};
-      result.changes = [];
-      resp['changes'] = resp['changes'] || [];
-      for (let i = 0; i < resp['changes'].length; i++) {
-        // github.com/juju/juju/apiserver/params#BundleChange
-        result.changes[i] = {};
-        resp['changes'][i] = resp['changes'][i] || {};
-        result.changes[i].id = resp['changes'][i]['id'];
-        result.changes[i].method = resp['changes'][i]['method'];
-        result.changes[i].args = [];
-        resp['changes'][i]['args'] = resp['changes'][i]['args'] || [];
-        for (let i2 = 0; i2 < resp['changes'][i]['args'].length; i2++) {
-          result.changes[i].args[i2] = resp['changes'][i]['args'][i2];
+      if (resp) {
+        result = {};
+        result.changes = [];
+        resp['changes'] = resp['changes'] || [];
+        for (let i = 0; i < resp['changes'].length; i++) {
+          // github.com/juju/juju/apiserver/params#BundleChange
+          if (resp['changes'][i]) {
+            result.changes[i] = {};
+            result.changes[i].id = resp['changes'][i]['id'];
+            result.changes[i].method = resp['changes'][i]['method'];
+            result.changes[i].args = [];
+            resp['changes'][i]['args'] = resp['changes'][i]['args'] || [];
+            for (let i2 = 0; i2 < resp['changes'][i]['args'].length; i2++) {
+              result.changes[i].args[i2] = resp['changes'][i]['args'][i2];
+            }
+            result.changes[i].requires = [];
+            resp['changes'][i]['requires'] = resp['changes'][i]['requires'] || [];
+            for (let i2 = 0; i2 < resp['changes'][i]['requires'].length; i2++) {
+              result.changes[i].requires[i2] = resp['changes'][i]['requires'][i2];
+            }
+          }
         }
-        result.changes[i].requires = [];
-        resp['changes'][i]['requires'] = resp['changes'][i]['requires'] || [];
-        for (let i2 = 0; i2 < resp['changes'][i]['requires'].length; i2++) {
-          result.changes[i].requires[i2] = resp['changes'][i]['requires'][i2];
+        result.errors = [];
+        resp['errors'] = resp['errors'] || [];
+        for (let i = 0; i < resp['errors'].length; i++) {
+          result.errors[i] = resp['errors'][i];
         }
-      }
-      result.errors = [];
-      resp['errors'] = resp['errors'] || [];
-      for (let i = 0; i < resp['errors'].length; i++) {
-        result.errors[i] = resp['errors'][i];
       }
       callback(null, result);
     });

--- a/tests/data/marshal.js
+++ b/tests/data/marshal.js
@@ -51,13 +51,14 @@ class MarshalV0 {
       // Handle the response.
       let result;
       // github.com/juju/juju/apiserver/params#AllWatcherNextResults
-      result = {};
-      resp = resp || {};
-      result.deltas = [];
-      resp['deltas'] = resp['deltas'] || [];
-      for (let i = 0; i < resp['deltas'].length; i++) {
-        // github.com/juju/juju/state/multiwatcher#Delta
-        result.deltas[i] = resp['deltas'][i];
+      if (resp) {
+        result = {};
+        result.deltas = [];
+        resp['deltas'] = resp['deltas'] || [];
+        for (let i = 0; i < resp['deltas'].length; i++) {
+          // github.com/juju/juju/state/multiwatcher#Delta
+          result.deltas[i] = resp['deltas'][i];
+        }
       }
       callback(null, result);
     });

--- a/tests/data/recursive.js
+++ b/tests/data/recursive.js
@@ -51,11 +51,12 @@ class RecursiveV47 {
       // Handle the response.
       let result;
       // github.com/juju/juju#RecursiveStruct
-      result = {};
-      resp = resp || {};
-      // github.com/juju/juju#RecursiveStruct
-      // TODO: handle recursive type referencing github.com/juju/juju#RecursiveStruct.
-      result.self = resp['self'];
+      if (resp) {
+        result = {};
+        // github.com/juju/juju#RecursiveStruct
+        // TODO: handle recursive type referencing github.com/juju/juju#RecursiveStruct.
+        result.self = resp['self'];
+      }
       callback(null, result);
     });
   }

--- a/tests/data/watcher.js
+++ b/tests/data/watcher.js
@@ -54,17 +54,19 @@ class AllWatcherV1 {
       // Handle the response.
       let result;
       // github.com/juju/juju/apiserver/params#AllWatcherNextResults
-      result = {};
-      resp = resp || {};
-      result.deltas = [];
-      resp['deltas'] = resp['deltas'] || [];
-      for (let i = 0; i < resp['deltas'].length; i++) {
-        // github.com/juju/juju/state/multiwatcher#Delta
-        result.deltas[i] = {};
-        resp['deltas'][i] = resp['deltas'][i] || {};
-        result.deltas[i].removed = resp['deltas'][i]['removed'];
-        // github.com/juju/juju/state/multiwatcher#EntityInfo
-        result.deltas[i].entity = resp['deltas'][i]['entity'];
+      if (resp) {
+        result = {};
+        result.deltas = [];
+        resp['deltas'] = resp['deltas'] || [];
+        for (let i = 0; i < resp['deltas'].length; i++) {
+          // github.com/juju/juju/state/multiwatcher#Delta
+          if (resp['deltas'][i]) {
+            result.deltas[i] = {};
+            result.deltas[i].removed = resp['deltas'][i]['removed'];
+            // github.com/juju/juju/state/multiwatcher#EntityInfo
+            result.deltas[i].entity = resp['deltas'][i]['entity'];
+          }
+        }
       }
       callback(null, result);
     });


### PR DESCRIPTION
Previously the API was sending empty JSON maps every time, which can confuse the Juju API.
This branch also includes nice to have wrappers (controller.watch for watching all models and client.addMachine for adding a single machine).
Also fix the AllModelWatcher by overriding the facade in wrappers so taht it accepts a watcher id.

Finally, implement connectAndLogin as many clients will never want the former without the latter, and they don't have to reimplement the connect and login dance including handling redirections every time.