### PR TITLE
Add missing is-controller

### DIFF
--- a/api/facades/model-manager-v5.js
+++ b/api/facades/model-manager-v5.js
@@ -1061,6 +1061,7 @@ class ModelManagerV5 {
                 result.results[i].result.type = resp['results'][i]['result']['type'];
                 result.results[i].result.uuid = resp['results'][i]['result']['uuid'];
                 result.results[i].result.controllerUuid = resp['results'][i]['result']['controller-uuid'];
+                result.results[i].result.isController = resp['results'][i]['result']['is-controller'];
                 result.results[i].result.providerType = resp['results'][i]['result']['provider-type'];
                 result.results[i].result.defaultSeries = resp['results'][i]['result']['default-series'];
                 result.results[i].result.cloudTag = resp['results'][i]['result']['cloud-tag'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/jujulib",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Juju API client",
   "main": "api/client.js",
   "scripts": {


### PR DESCRIPTION
For some reason the `is-controller` key was missing from the generated schema output. I've manually added it back in here.