### PR TITLE
Improve docs readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ WebSocket API.
 
 - [Getting Started](#getting-started)
 - [Client API Reference](#client-api-reference)
-- [Facade API Reference](#facade-api-reference)
 - [Examples](#examples)
+- [Facade API Reference](#facade-api-reference)
 - [Library Maintenance](#library-maintenance)
   - [Updating Library Facades](#updating-library-facades)
   - [Releasing to NPM](#releasing-to-npm)
@@ -46,6 +46,17 @@ The `connect` method returns a `juju` object which is used to log into the contr
 ## Client API Reference
 
 Visit the [full API documentation](https://juju.github.io/js-libjuju/) for detailed information on the Client API.
+
+## Examples
+
+We have a number of examples showing how to perform a few common tasks. Those can be found in the `examples` folder.
+
+- [add-machine.js](examples/add-machine.js)
+- [deploy.js](examples/deploy.js)
+- [login-with-bakery.js](examples/login-with-bakery.js)
+- [ping.js](examples/ping.js)
+- [watch-all-models.js](examples/watch-all-models.js)
+- [watch.js](examples/watch.js)
 
 ## Facade API Reference
 
@@ -170,17 +181,6 @@ Detailed Facade documentation is available as part of the [full API documentatio
 | UserManager                  | <ul><li>[v1.ts](/api/facades/user-manager/v1.ts)</li><li>[v2.ts](/api/facades/user-manager/v2.ts)</li><li>[v3.ts](/api/facades/user-manager/v3.ts)</li></ul>                                                                                                                                                                                                                                        |
 | VolumeAttachmentPlansWatcher | <ul><li>[v1.ts](/api/facades/volume-attachment-plans-watcher/v1.ts)</li></ul>                                                                                                                                                                                                                                                                                                                       |
 | VolumeAttachmentsWatcher     | <ul><li>[v2.ts](/api/facades/volume-attachments-watcher/v2.ts)</li></ul>                                                                                                                                                                                                                                                                                                                            |
-
-## Examples
-
-We have a number of examples showing how to perform a few common tasks. Those can be found in the `examples` folder.
-
-- [add-machine.js](examples/add-machine.js)
-- [deploy.js](examples/deploy.js)
-- [login-with-bakery.js](examples/login-with-bakery.js)
-- [ping.js](examples/ping.js)
-- [watch-all-models.js](examples/watch-all-models.js)
-- [watch.js](examples/watch.js)
 
 ## Library Maintenance
 

--- a/generator/templates/readme.ts
+++ b/generator/templates/readme.ts
@@ -14,8 +14,8 @@ WebSocket API.
 
 - [Getting Started](#getting-started)
 - [Client API Reference](#client-api-reference)
-- [Facade API Reference](#facade-api-reference)
 - [Examples](#examples)
+- [Facade API Reference](#facade-api-reference)
 - [Library Maintenance](#library-maintenance)
   - [Updating Library Facades](#updating-library-facades)
   - [Releasing to NPM](#releasing-to-npm)
@@ -51,6 +51,16 @@ The \`connect\` method returns a \`juju\` object which is used to log into the c
 
 Visit the [full API documentation](https://juju.github.io/js-libjuju/) for detailed information on the Client API.
 
+## Examples
+
+We have a number of examples showing how to perform a few common tasks. Those can be found in the \`examples\` folder.
+
+${r.exampleList
+  .map((e) => {
+    return `- [${e.name}](${e.path})`;
+  })
+  .join("\n")}
+
 ## Facade API Reference
 
 Detailed Facade documentation is available as part of the [full API documentation](https://juju.github.io/js-libjuju/) or you can visit the facade source directly using the following links:
@@ -63,16 +73,6 @@ ${Object.keys(r.facadeList)
       .map((f) => `<li>[${f.name}](${f.path})</li>`)
       .join("");
     return `|${facadeName}|<ul>${versionsList}</ul>|`;
-  })
-  .join("\n")}
-
-## Examples
-
-We have a number of examples showing how to perform a few common tasks. Those can be found in the \`examples\` folder.
-
-${r.exampleList
-  .map((e) => {
-    return `- [${e.name}](${e.path})`;
   })
   .join("\n")}
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "generate-facades": "SCHEMA=generator/schema/schema.json JUJU_VERSION=`cat generator/schema/juju-version.txt` JUJU_GIT_SHA=`cat generator/schema/juju-git-sha.txt` node --enable-source-maps dist/generator/index.js",
     "regenerate-all-facades": "node generator/schema/regenerate-all.js",
     "store-schema": "./scripts/store-schema.sh",
-    "generate-docs": "typedoc api/* --out docs --entryPointStrategy expand --includeVersion --gitRemote upstream",
+    "generate-docs": "README_FOR_DOCS=true yarn generate-facades && typedoc api/* --out docs --entryPointStrategy expand --includeVersion --gitRemote upstream",
     "lint": "eslint api/",
     "format": "prettier --write '**/*.(js|ts|json|md)' && eslint --fix .",
     "test": "tap 'api/tests/test-!(helpers)*.js'"


### PR DESCRIPTION
## Description

- Use Absolute URL paths for links in the README in the context of the docs: https://juju.github.io/js-libjuju/
- Move the examples code snippets to the top of the facades list

### Issues

Fixes #90 #46