### PR TITLE
Add checkForJujuUpdate to utils for checking for Juju updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.dotrun.json
 .vscode
 *.map
 node_modules/

--- a/api/client.ts
+++ b/api/client.ts
@@ -8,7 +8,6 @@
 */
 
 import { Bakery } from "@canonical/macaroon-bakery";
-import schemaList from "../generator/schema/schema-history.json";
 import AdminV3, {
   FacadeVersions,
   LoginRequest,
@@ -28,8 +27,7 @@ import {
   FacadeClassList,
   GenericFacade,
 } from "./types.js";
-import { createAsyncHandler, jujuVersions, parseVersion } from "./utils.js";
-
+import { createAsyncHandler } from "./utils.js";
 export interface ConnectOptions {
   bakery?: Bakery | null;
   closeCallback: Callback<number>;
@@ -617,23 +615,3 @@ export {
   generateModelURL,
   RedirectionError,
 };
-
-/**
- * Check if the Juju Model or Controller has an update available
- * @param version The version of the Juju Model or Controller
- */
-export function checkForJujuUpdate(version: string): boolean {
-  const [majorVersion, minorVersion] = parseVersion(version);
-  // check again that latest release jujuVersions
-  const latestAvailableVersion = jujuVersions(schemaList).slice(-1)[0];
-  const [latestMajorVersion, latestMinorVersion] = parseVersion(
-    latestAvailableVersion
-  );
-  if (
-    majorVersion < latestMajorVersion ||
-    (majorVersion === latestMajorVersion && minorVersion < latestMinorVersion)
-  ) {
-    return true;
-  }
-  return false;
-}

--- a/api/client.ts
+++ b/api/client.ts
@@ -8,6 +8,7 @@
 */
 
 import { Bakery } from "@canonical/macaroon-bakery";
+import schemaList from "../generator/schema/schema-history.json";
 import AdminV3, {
   FacadeVersions,
   LoginRequest,
@@ -27,7 +28,7 @@ import {
   FacadeClassList,
   GenericFacade,
 } from "./types.js";
-import { createAsyncHandler } from "./utils.js";
+import { createAsyncHandler, jujuVersions, parseVersion } from "./utils.js";
 
 export interface ConnectOptions {
   bakery?: Bakery | null;
@@ -616,3 +617,23 @@ export {
   generateModelURL,
   RedirectionError,
 };
+
+/**
+ * Check if the Juju Model or Controller has an update available
+ * @param version The version of the Juju Model or Controller
+ */
+export function checkForJujuUpdate(version: string): boolean {
+  const [majorVersion, minorVersion] = parseVersion(version);
+  // check again that latest release jujuVersions
+  const latestAvailableVersion = jujuVersions(schemaList).slice(-1)[0];
+  const [latestMajorVersion, latestMinorVersion] = parseVersion(
+    latestAvailableVersion
+  );
+  if (
+    majorVersion < latestMajorVersion ||
+    (majorVersion === latestMajorVersion && minorVersion < latestMinorVersion)
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/api/tests/test-client.ts
+++ b/api/tests/test-client.ts
@@ -3,6 +3,16 @@
 
 "use strict";
 
+import { CallbackError } from "../../generator/interfaces";
+import {
+  checkForJujuUpdate,
+  Client,
+  connect,
+  connectAndLogin,
+  Connection,
+  generateModelURL,
+  RedirectionError,
+} from "../client";
 import {
   BaseFacade,
   makeBakery,
@@ -11,16 +21,7 @@ import {
   MockWebSocket,
   requestEqual,
 } from "./helpers";
-import {
-  Client,
-  connect,
-  connectAndLogin,
-  Connection,
-  generateModelURL,
-  RedirectionError,
-} from "../client";
-import { CallbackError } from "../../generator/interfaces";
-
+import * as utils from "../utils";
 const fail = () => {
   throw new Error("Fail called");
 };
@@ -690,5 +691,33 @@ describe("generateModelURL", () => {
     expect(generateModelURL("1.2.3.4:123", "abc-123-4")).toBe(
       "wss://1.2.3.4:123/model/abc-123-4/api"
     );
+  });
+});
+
+describe("jujuVersions", () => {
+  it("returns a sorted list of versions", () => {
+    expect(
+      utils.jujuVersions([
+        { "juju-version": "2.8.0" },
+        { "juju-version": "3.1.2" },
+        { "juju-version": "2.9.9" },
+        { "juju-version": "2.9.1" },
+      ])
+    ).toEqual(["2.8.0", "2.9.1", "2.9.9", "3.1.2"]);
+  });
+});
+
+describe("checkForJujuUpdate", () => {
+  beforeAll(() => {
+    jest.spyOn(utils, "jujuVersions").mockImplementation(() => ["2.9.10"]);
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+  it("returns false if no update available", () => {
+    expect(checkForJujuUpdate("2.9.10")).toBe(false);
+  });
+  it("returns true if update available", () => {
+    expect(checkForJujuUpdate("2.8.0")).toBe(true);
   });
 });

--- a/api/tests/test-client.ts
+++ b/api/tests/test-client.ts
@@ -5,7 +5,6 @@
 
 import { CallbackError } from "../../generator/interfaces";
 import {
-  checkForJujuUpdate,
   Client,
   connect,
   connectAndLogin,
@@ -21,7 +20,6 @@ import {
   MockWebSocket,
   requestEqual,
 } from "./helpers";
-import * as utils from "../utils";
 const fail = () => {
   throw new Error("Fail called");
 };
@@ -691,33 +689,5 @@ describe("generateModelURL", () => {
     expect(generateModelURL("1.2.3.4:123", "abc-123-4")).toBe(
       "wss://1.2.3.4:123/model/abc-123-4/api"
     );
-  });
-});
-
-describe("jujuVersions", () => {
-  it("returns a sorted list of versions", () => {
-    expect(
-      utils.jujuVersions([
-        { "juju-version": "2.8.0" },
-        { "juju-version": "3.1.2" },
-        { "juju-version": "2.9.9" },
-        { "juju-version": "2.9.1" },
-      ])
-    ).toEqual(["2.8.0", "2.9.1", "2.9.9", "3.1.2"]);
-  });
-});
-
-describe("checkForJujuUpdate", () => {
-  beforeAll(() => {
-    jest.spyOn(utils, "jujuVersions").mockImplementation(() => ["2.9.10"]);
-  });
-  afterAll(() => {
-    jest.restoreAllMocks();
-  });
-  it("returns false if no update available", () => {
-    expect(checkForJujuUpdate("2.9.10")).toBe(false);
-  });
-  it("returns true if update available", () => {
-    expect(checkForJujuUpdate("2.8.0")).toBe(true);
   });
 });

--- a/api/tests/test-versions.ts
+++ b/api/tests/test-versions.ts
@@ -1,0 +1,25 @@
+import { jujuUpdateAvailable } from "../versions";
+
+describe("versions", () => {
+  // mock fetch: https://juju.is/latest.json
+  const mockFetch = jest.fn();
+  mockFetch.mockReturnValue({
+    json: () => ({
+      dashboard: "2.8.1",
+      juju: ["2.8.1", "2.8.0", "2.7.9"],
+    }),
+  });
+  global.fetch = mockFetch;
+  it("should return true if the Juju controller version is old", async () => {
+    expect(await jujuUpdateAvailable("2.7.8")).toBe(true);
+  });
+  it("should return false if the Juju controller version is new", async () => {
+    expect(await jujuUpdateAvailable("2.8.1")).toBe(false);
+  });
+  it("should return true if the Juju dashboard version is old", async () => {
+    expect(await jujuUpdateAvailable("2.2.0")).toBe(true);
+  });
+  it("should return false if the Juju dashboard version is new", async () => {
+    expect(await jujuUpdateAvailable("2.8.1")).toBe(false);
+  });
+});

--- a/api/tests/test-versions.ts
+++ b/api/tests/test-versions.ts
@@ -1,4 +1,4 @@
-import { jujuUpdateAvailable } from "../versions";
+import { cachedAPIResponse, jujuUpdateAvailable } from "../versions";
 
 describe("versions", () => {
   // mock fetch: https://juju.is/latest.json
@@ -21,5 +21,14 @@ describe("versions", () => {
   });
   it("should return false if the Juju dashboard version is new", async () => {
     expect(await jujuUpdateAvailable("2.8.1")).toBe(false);
+  });
+  it("should use TTL to cache the response", async () => {
+    await jujuUpdateAvailable("2.7.8");
+    await jujuUpdateAvailable("2.7.8");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // invalidate the cache
+    cachedAPIResponse?.fetchedAt.setTime(0);
+    await jujuUpdateAvailable("2.7.8");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/api/utils.ts
+++ b/api/utils.ts
@@ -48,3 +48,26 @@ export function createAsyncHandler<T>(
     callback ? callback(null, value) : resolve(value!);
   };
 }
+
+export const parseVersion = (version: string): number[] =>
+  version.split(".").map((v) => parseInt(v));
+
+export const jujuVersions = (schemaList: { "juju-version": string }[]) =>
+  schemaList
+    .map((schema) => schema["juju-version"])
+    // sort by version
+    .sort((v1, v2) => {
+      const v1Parts = parseVersion(v1);
+      const v2Parts = parseVersion(v2);
+
+      for (let i = 0; i < v1Parts.length; i++) {
+        const v1Part = v1Parts[i];
+        const v2Part = v2Parts[i];
+        if (v1Part < v2Part) {
+          return -1;
+        } else if (v1Part > v2Part) {
+          return 1;
+        }
+      }
+      return 0;
+    });

--- a/api/utils.ts
+++ b/api/utils.ts
@@ -48,26 +48,3 @@ export function createAsyncHandler<T>(
     callback ? callback(null, value) : resolve(value!);
   };
 }
-
-export const parseVersion = (version: string): number[] =>
-  version.split(".").map((v) => parseInt(v));
-
-export const jujuVersions = (schemaList: { "juju-version": string }[]) =>
-  schemaList
-    .map((schema) => schema["juju-version"])
-    // sort by version
-    .sort((v1, v2) => {
-      const v1Parts = parseVersion(v1);
-      const v2Parts = parseVersion(v2);
-
-      for (let i = 0; i < v1Parts.length; i++) {
-        const v1Part = v1Parts[i];
-        const v2Part = v2Parts[i];
-        if (v1Part < v2Part) {
-          return -1;
-        } else if (v1Part > v2Part) {
-          return 1;
-        }
-      }
-      return 0;
-    });

--- a/api/versions.ts
+++ b/api/versions.ts
@@ -1,0 +1,71 @@
+export const parseVersion = (version: string): number[] =>
+  version.split(".").map((v) => parseInt(v));
+
+const versionGreaterThan = (v1: string, v2: string): boolean => {
+  const v1Parts = parseVersion(v1);
+  const v2Parts = parseVersion(v2);
+  for (let i = 0; i < v1Parts.length; i++) {
+    const v1Part = v1Parts[i];
+    const v2Part = v2Parts[i];
+    if (v1Part > v2Part) {
+      return true;
+    } else if (v1Part < v2Part) {
+      return false;
+    }
+  }
+  return false;
+};
+
+const sortVersions = (versions: string[]): string[] =>
+  versions.sort((v1, v2) => {
+    if (versionGreaterThan(v1, v2)) {
+      return -1;
+    } else if (versionGreaterThan(v2, v1)) {
+      return 1;
+    }
+    return 0;
+  });
+
+type APIPayload = {
+  dashboard: string;
+  juju: string[];
+};
+/**
+ * Avoid making multiple requests to the API by caching the response.
+ */
+let cachedAPIResponse: APIPayload | null = null;
+
+/**
+ * Fetch the latest Juju versions from the API.
+ */
+const fetchVersions = async () => {
+  if (cachedAPIResponse) return cachedAPIResponse;
+  const response = await fetch("https://juju.is/latest.json");
+  const data = await response.json();
+  cachedAPIResponse = { ...data, juju: sortVersions(data.juju) };
+  return data;
+};
+
+/**
+ * Check the Juju controller version against the latest available
+ * version (ignores the patch version).
+ * @param jujuVersion The version of the Juju controller to check
+ * @returns
+ */
+export const jujuUpdateAvailable = async (jujuVersion: string) => {
+  const jujuVersions = (cachedAPIResponse || (await fetchVersions())).juju;
+  const latestAvailableVersion = jujuVersions.slice(-1)[0];
+  return versionGreaterThan(latestAvailableVersion, jujuVersion);
+};
+
+/**
+ * Check the Juju dashboard version against the latest available
+ * version (ignore the patch version).
+ * @param dashboardVersion The version of the Juju dashboard to check
+ * @returns
+ */
+export const dashboardUpdateAvailable = async (dashboardVersion: string) => {
+  const latestDashboardVersion = (cachedAPIResponse || (await fetchVersions()))
+    .dashboard;
+  return versionGreaterThan(latestDashboardVersion, dashboardVersion);
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/jujulib",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Juju API client",
   "main": "dist/api/client.js",
   "types": "dist/api/client.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "Node",
     "sourceMap": true,
     "outDir": "dist",
-    "declaration": true
+    "declaration": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## Description

- The original idea was to check Juju models for updates using the facade `modelUpgrader.upgradeModel` but that isn't working as expected
- The new idea is to get the latest version that is supported by Jujulib and notify the user for updates in case there is a new major or minor update


## Issues

https://warthogs.atlassian.net/browse/WD-2389