### PR TITLE
Catch login errors

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -28,6 +28,7 @@ import {
   GenericFacade,
 } from "./types.js";
 import { createAsyncHandler } from "./utils.js";
+import { Macaroon } from "./facades/admin/AdminV3";
 export interface ConnectOptions {
   bakery?: Bakery | null;
   closeCallback: Callback<number>;
@@ -283,9 +284,15 @@ class Client {
 
     // eslint-disable-next-line no-async-promise-executor
     return await new Promise(async (resolve, reject) => {
-      const response: any = await this._admin.login(args);
+      let response: any;
       try {
-        const dischargeRequired: string | undefined =
+        response = await this._admin.login(args);
+      } catch (error) {
+        reject(error);
+        return;
+      }
+      try {
+        const dischargeRequired =
           response["discharge-required"] ||
           response["bakery-discharge-required"];
         if (dischargeRequired) {

--- a/api/tests/test-client.ts
+++ b/api/tests/test-client.ts
@@ -86,6 +86,17 @@ describe("connect", () => {
     expect(error).toBe("bad wolf");
   }
 
+  it("handles admin login failures", (done) => {
+    connect("wss://1.2.3.4", options).then((juju: Client) => {
+      ws.close("");
+      juju?.login({ username: "who", password: "secret" }).catch((error) => {
+        expect(error).toContain("cannot send request");
+        done();
+      });
+    });
+    ws.open();
+  });
+
   it("login failure via promise", (done) => {
     connect("wss://1.2.3.4", options).then((juju: Client) => {
       juju


### PR DESCRIPTION
Catch and return errors when logging in via the admin facade.

This required for: https://github.com/canonical/jaas-dashboard/issues/491