### PR TITLE
WD-9334 - fix: use callback resolve and reject

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -339,8 +339,7 @@ class Client {
         }
         resolve(new Connection(this._transport, this._facades, response));
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : error;
-        if (errorMessage !== REDIRECTION_ERROR) {
+        if (error instanceof Error && error.message !== REDIRECTION_ERROR) {
           reject(toError(error));
           return;
         }
@@ -348,10 +347,8 @@ class Client {
         try {
           const info = await this._admin.redirectInfo(null);
           reject(new RedirectionError(info));
-          return;
         } catch (error) {
           reject(toError(error));
-          return;
         }
       }
     });

--- a/api/client.ts
+++ b/api/client.ts
@@ -21,7 +21,6 @@ import {
   MacaroonObject,
 } from "@canonical/macaroon-bakery/dist/macaroon";
 import type { Callback, JujuRequest } from "../generator/interfaces";
-import { toError } from "./helpers.js";
 import {
   ClassType,
   Facade,
@@ -29,7 +28,7 @@ import {
   FacadeClassList,
   GenericFacade,
 } from "./types.js";
-import { createAsyncHandler } from "./utils.js";
+import { createAsyncHandler, toError } from "./utils.js";
 
 export const CLIENT_VERSION = "3.3.2";
 

--- a/api/client.ts
+++ b/api/client.ts
@@ -339,7 +339,7 @@ class Client {
         }
         resolve(new Connection(this._transport, this._facades, response));
       } catch (error) {
-        if (error instanceof Error && error.message !== REDIRECTION_ERROR) {
+        if (!(error instanceof Error) || error.message !== REDIRECTION_ERROR) {
           reject(toError(error));
           return;
         }

--- a/api/client.ts
+++ b/api/client.ts
@@ -292,11 +292,17 @@ class Client {
         try {
           response = await this._admin.login(args);
         } catch (error) {
-          if (error === INVALIDCREDENTIALS_ERROR) {
+          if (
+            error instanceof Error &&
+            error.message === INVALIDCREDENTIALS_ERROR
+          ) {
             throw new Error(
               "Have you been granted permission to a model on this controller?"
             );
-          } else if (response === PERMISSIONDENIED_ERROR) {
+          } else if (
+            error instanceof Error &&
+            error.message === PERMISSIONDENIED_ERROR
+          ) {
             throw new Error(
               "Ensure that you've been given 'login' permission on this controller."
             );

--- a/api/helpers.ts
+++ b/api/helpers.ts
@@ -10,10 +10,6 @@ import type { Callback, CallbackError } from "../generator/interfaces";
 import type PingerV1 from "./facades/pinger/PingerV1.js";
 import { createAsyncHandler } from "./utils.js";
 
-export enum Label {
-  UNKNOWN_ERROR = "Unknown error",
-}
-
 /**
   Decorate the Admin facade class.
 
@@ -110,7 +106,7 @@ function wrapAllModelWatcher(cls: any) {
   */
   cls.prototype.next = function (
     watcherId: string,
-    callback: any
+    callback: Callback<any>
   ): Promise<any> {
     // This method is overridden as the auto-generated one does not include the
     // watcherId parameter, as a result of the peculiarity of the call, which
@@ -147,7 +143,7 @@ function wrapAllModelWatcher(cls: any) {
   */
   cls.prototype.stop = function (
     watcherId: string,
-    callback: any
+    callback: Callback<any>
   ): Promise<any> {
     // This method is overridden as the auto-generated one does not include the
     // watcherId parameter, as a result of the peculiarity of the call, which
@@ -193,7 +189,7 @@ function wrapAllWatcher(cls: any) {
   */
   cls.prototype.next = function (
     watcherId: string,
-    callback: any
+    callback: Callback<any>
   ): Promise<any> {
     // This method is overridden as the auto-generated one does not include the
     // watcherId parameter, as a result of the peculiarity of the call, which
@@ -230,7 +226,7 @@ function wrapAllWatcher(cls: any) {
   */
   cls.prototype.stop = function (
     watcherId: string,
-    callback: any
+    callback: Callback<any>
   ): Promise<any> {
     // This method is overridden as the auto-generated one does not include the
     // watcherId parameter, as a result of the peculiarity of the call, which
@@ -277,7 +273,7 @@ function wrapClient(cls: any) {
   */
   cls.prototype.watch = function (callback: Callback<any>): object | undefined {
     if (!callback) {
-      callback = (_error: CallbackError, _result: any) => {};
+      callback = (_error: CallbackError, _result?: any) => {};
     }
     // Check that the AllWatcher facade is loaded, as we will use it.
     const allWatcher = this._info.getFacade("allWatcher");
@@ -291,8 +287,8 @@ function wrapClient(cls: any) {
       if (!watcherId) {
         return;
       }
-      allWatcher.next(watcherId, (err: CallbackError, result: any) => {
-        callback(err, result);
+      allWatcher.next(watcherId, (error: CallbackError, result: any) => {
+        callback(error, result);
         next(callback);
       });
     };
@@ -346,7 +342,7 @@ function wrapController(cls: any) {
   */
   cls.prototype.watch = function (callback: Callback<any>): object | undefined {
     if (!callback) {
-      callback = (_error: CallbackError, _result: any) => {};
+      callback = (_error: CallbackError, _result?: any) => {};
     }
     // Check that the AllModelWatcher facade is loaded, as we will use it.
     const allModelWatcher: any = this._info.getFacade("allModelWatcher");
@@ -415,22 +411,6 @@ export function pingForever(
   return () => {
     clearInterval(timer);
   };
-}
-
-/**
-  Convert given input to an Error object.
-
-  @param error - The input to be converted to an Error object.
-  @returns An Error object.
-*/
-export function toError(error: any): Error {
-  if (error instanceof Error) {
-    return error;
-  }
-  if (typeof error === "string") {
-    return new Error(error);
-  }
-  return new Error(Label.UNKNOWN_ERROR);
 }
 
 export {

--- a/api/helpers.ts
+++ b/api/helpers.ts
@@ -272,9 +272,6 @@ function wrapClient(cls: any) {
       method which can be provided a callback receiving an error.
   */
   cls.prototype.watch = function (callback: Callback<any>): object | undefined {
-    if (!callback) {
-      callback = (_error: CallbackError, _result?: any) => {};
-    }
     // Check that the AllWatcher facade is loaded, as we will use it.
     const allWatcher = this._info.getFacade("allWatcher");
     if (!allWatcher) {
@@ -341,9 +338,6 @@ function wrapController(cls: any) {
       method which can be provided a callback receiving an error.
   */
   cls.prototype.watch = function (callback: Callback<any>): object | undefined {
-    if (!callback) {
-      callback = (_error: CallbackError, _result?: any) => {};
-    }
     // Check that the AllModelWatcher facade is loaded, as we will use it.
     const allModelWatcher: any = this._info.getFacade("allModelWatcher");
     if (!allModelWatcher) {

--- a/api/tests/helpers.ts
+++ b/api/tests/helpers.ts
@@ -188,7 +188,7 @@ export class MockWebSocket {
   }
 
   onopen() {}
-  onclose(_params: { reason: string }) {}
+  onclose(_params: { reason: string; code: number; wasClean: boolean }) {}
   onmessage(_params: { data: string }) {}
 
   open() {
@@ -196,9 +196,9 @@ export class MockWebSocket {
     this.onopen();
   }
 
-  close(reason: string) {
+  close(reason: string, code = 1000, wasClean = true) {
     this.readyState = 3;
-    this.onclose({ reason: reason });
+    this.onclose({ reason, code, wasClean });
   }
 
   message(msg: string) {

--- a/api/tests/test-client.ts
+++ b/api/tests/test-client.ts
@@ -170,6 +170,28 @@ describe("connect", () => {
     ws.open();
   });
 
+  it("login generic redirection error failure via promise", (done) => {
+    connect("wss://1.2.3.4", options).then((juju: Client) => {
+      // juju._admin.redirectInfo = jest.fn().mockImplementation(() => null);
+      juju
+        ?.login({})
+        .then(() => fail)
+        .catch((error) => {
+          expect(error).toStrictEqual(new Error("bad wolf"));
+          done();
+        });
+      ws.queueResponses(
+        new Map([
+          // Reply to the redirectInfo request.
+          [2, { error: "bad wolf" }],
+        ])
+      );
+      // Reply to the login request.
+      ws.reply({ error: "redirection required" });
+    });
+    ws.open();
+  });
+
   function validateRedirectionLoginSuccess(
     juju: Client,
     error: RedirectionError

--- a/api/tests/test-client.ts
+++ b/api/tests/test-client.ts
@@ -162,7 +162,6 @@ describe("connect", () => {
 
   it("login redirection error failure via promise", (done) => {
     connect("wss://1.2.3.4", options).then((juju: Client) => {
-      // juju._admin.redirectInfo = jest.fn().mockImplementation(() => null);
       juju
         ?.login({})
         .then(() => fail)
@@ -206,7 +205,6 @@ describe("connect", () => {
 
   it("login generic redirection error failure via promise", (done) => {
     connect("wss://1.2.3.4", options).then((juju: Client) => {
-      // juju._admin.redirectInfo = jest.fn().mockImplementation(() => null);
       juju
         ?.login({})
         .then(() => fail)

--- a/api/tests/test-client.ts
+++ b/api/tests/test-client.ts
@@ -13,7 +13,6 @@ import {
   RedirectionError,
   CLIENT_VERSION,
 } from "../client";
-import { toError } from "../helpers";
 import {
   BaseFacade,
   makeBakery,
@@ -22,6 +21,7 @@ import {
   MockWebSocket,
   requestEqual,
 } from "./helpers";
+import { toError } from "../utils";
 const fail = () => {
   throw new Error("Fail called");
 };

--- a/api/tests/test-client.ts
+++ b/api/tests/test-client.ts
@@ -299,8 +299,8 @@ describe("connect", () => {
       },
       version: 3,
     });
-    expect(error).toBe(
-      "macaroon discharge required but no bakery instance provided"
+    expect(error).toStrictEqual(
+      new Error("macaroon discharge required but no bakery instance provided")
     );
   }
 
@@ -363,7 +363,9 @@ describe("connect", () => {
       },
       version: 3,
     });
-    expect(error).toBe("macaroon discharge failed: bad wolf");
+    expect(error).toStrictEqual(
+      new Error("macaroon discharge failed: bad wolf")
+    );
   }
 
   it("login discharge required failure", (done) => {

--- a/api/tests/test-client.ts
+++ b/api/tests/test-client.ts
@@ -577,11 +577,19 @@ describe("connectAndLogin", () => {
     connectAndLogin(url, creds, options)
       .then(() => fail)
       .catch((error) => {
-        expect(error.message).toBe("cannot connect to model after redirection");
+        console.log("error", error);
+        expect(error).toBe("redirection required");
         requestEqual(ws.lastRequest, {
           type: "Admin",
-          request: "RedirectInfo",
-          params: null,
+          request: "Login",
+          params: {
+            "auth-tag": "",
+            "client-version": "3.3.2",
+            credentials: "",
+            macaroons: ["fake macaroon"],
+            nonce: "",
+            "user-data": "",
+          },
           version: 3,
         });
         done();
@@ -590,8 +598,6 @@ describe("connectAndLogin", () => {
       new Map([
         // Reply to the login request.
         [1, { error: "redirection required" }],
-        // Reply to the redirectInfo request.
-        [2, { response: { servers: [], "ca-cert": null } }],
       ])
     );
     // Open the WebSocket connection.

--- a/api/tests/test-transform.ts
+++ b/api/tests/test-transform.ts
@@ -3,7 +3,7 @@
 
 "use strict";
 
-import { autoBind, createAsyncHandler } from "../utils";
+import { autoBind, createAsyncHandler, toError, Label } from "../utils";
 
 describe("autoBind", () => {
   interface Question {
@@ -109,5 +109,19 @@ describe("createAsyncHandler", () => {
     );
     fn.resolve(10);
     expect(cb.mock.calls[0][1]).toBe(20);
+  });
+});
+
+describe("toError", () => {
+  it("handles error objects", () => {
+    expect(toError(new Error("Uh oh!"))).toStrictEqual(new Error("Uh oh!"));
+  });
+
+  it("handles error strings", () => {
+    expect(toError("Uh oh!")).toStrictEqual(new Error("Uh oh!"));
+  });
+
+  it("handles unknown errors", () => {
+    expect(toError(false)).toStrictEqual(new Error(Label.UNKNOWN_ERROR));
   });
 });

--- a/api/tests/test-transform.ts
+++ b/api/tests/test-transform.ts
@@ -54,31 +54,37 @@ describe("autoBind", () => {
 });
 
 describe("createAsyncHandler", () => {
-  it("returns a function and all arguments are optional", () => {
+  it("returns an object with reject and resolve function", () => {
     expect(typeof createAsyncHandler(jest.fn(), jest.fn(), jest.fn())).toBe(
-      "function"
+      "object"
     );
+    expect(
+      typeof createAsyncHandler(jest.fn(), jest.fn(), jest.fn()).reject
+    ).toBe("function");
+    expect(
+      typeof createAsyncHandler(jest.fn(), jest.fn(), jest.fn()).resolve
+    ).toBe("function");
   });
 
   it("calls callback with successful value", () => {
     const cb = jest.fn();
     const fn = createAsyncHandler(cb, jest.fn(), jest.fn());
-    fn(null, "party");
+    fn.resolve("party");
     expect(cb.mock.calls[0]).toEqual([null, "party"]);
   });
 
   it("calls callback with error value", () => {
     const cb = jest.fn();
     const fn = createAsyncHandler(cb, jest.fn(), jest.fn());
-    fn("boo", {});
-    expect(cb.mock.calls[0][0]).toEqual("boo");
+    fn.reject(new Error("boo"));
+    expect(cb.mock.calls[0][0]).toStrictEqual(new Error("boo"));
   });
 
   it("resolves promise with successful value", () => {
     expect(
       new Promise((resolve, reject) => {
         const fn = createAsyncHandler(undefined, resolve, reject);
-        fn(null, "party");
+        fn.resolve("party");
       })
     ).resolves.toBe("party");
   });
@@ -87,9 +93,9 @@ describe("createAsyncHandler", () => {
     expect(
       new Promise((resolve, reject) => {
         const fn = createAsyncHandler(undefined, resolve, reject);
-        fn("boo", "party");
+        fn.reject(new Error("boo"));
       })
-    ).rejects.toBe("boo");
+    ).rejects.toStrictEqual(new Error("boo"));
   });
 
   it("transforms value if function provided", () => {
@@ -101,7 +107,7 @@ describe("createAsyncHandler", () => {
       () => null,
       transform
     );
-    fn(null, 10);
+    fn.resolve(10);
     expect(cb.mock.calls[0][1]).toBe(20);
   });
 });

--- a/api/tests/test-wrappers.ts
+++ b/api/tests/test-wrappers.ts
@@ -17,8 +17,14 @@ describe("wrapAllModelWatcher", () => {
     static NAME = "AllModelWatcher";
     static VERSION = 1;
 
-    next(_id: number, _callback: (result: Response | CallbackError) => void) {}
-    stop(_id: number, _callback: (result: Response | CallbackError) => void) {}
+    next(
+      _id: number,
+      _callback: (error: CallbackError, result?: Response) => void
+    ) {}
+    stop(
+      _id: number,
+      _callback: (error: CallbackError, result?: Response) => void
+    ) {}
   }
   const options = {
     closeCallback: jest.fn(),
@@ -31,7 +37,7 @@ describe("wrapAllModelWatcher", () => {
         "allModelWatcher"
       ) as AllModelWatcherV1;
       const watcherId = 42;
-      allModelWatcher?.next(watcherId, (result) => {
+      allModelWatcher?.next(watcherId, (_error, result) => {
         requestEqual(ws.lastRequest, {
           type: "AllModelWatcher",
           request: "Next",
@@ -65,7 +71,7 @@ describe("wrapAllModelWatcher", () => {
       ) as AllModelWatcherV1;
       const watcherId = 42;
       allModelWatcher?.next(watcherId, (err) => {
-        expect(err).toBe("bad wolf");
+        expect(err).toStrictEqual(new Error("bad wolf"));
       });
       // Reply to the next request.
       ws.reply({ error: "bad wolf" });
@@ -79,7 +85,7 @@ describe("wrapAllModelWatcher", () => {
         "allModelWatcher"
       ) as AllModelWatcherV1;
       const watcherId = 42;
-      allModelWatcher?.stop(watcherId, (result) => {
+      allModelWatcher?.stop(watcherId, (_error, result) => {
         requestEqual(ws.lastRequest, {
           type: "AllModelWatcher",
           request: "Stop",
@@ -101,7 +107,7 @@ describe("wrapAllModelWatcher", () => {
       ) as AllModelWatcherV1;
       const watcherId = 42;
       allModelWatcher?.stop(watcherId, (err) => {
-        expect(err).toBe("bad wolf");
+        expect(err).toStrictEqual(new Error("bad wolf"));
       });
       // Reply to the next request.
       ws.reply({ error: "bad wolf" });
@@ -115,8 +121,14 @@ describe("wrapAllWatcher", () => {
     static NAME = "AllWatcher";
     static VERSION = 0;
 
-    next(_id: number, _callback: (result: Response | CallbackError) => void) {}
-    stop(_id: number, _callback: (result: Response | CallbackError) => void) {}
+    next(
+      _id: number,
+      _callback: (error: CallbackError, result?: Response) => void
+    ) {}
+    stop(
+      _id: number,
+      _callback: (error: CallbackError, result?: Response) => void
+    ) {}
   }
   const options = {
     closeCallback: jest.fn(),
@@ -127,7 +139,7 @@ describe("wrapAllWatcher", () => {
     makeConnection(options, (conn, ws) => {
       const allWatcher = conn?.info.getFacade?.("allWatcher") as AllWatcherV0;
       const watcherId = 42;
-      allWatcher?.next(watcherId, (result) => {
+      allWatcher?.next(watcherId, (_error, result) => {
         requestEqual(ws.lastRequest, {
           type: "AllWatcher",
           request: "Next",
@@ -159,7 +171,7 @@ describe("wrapAllWatcher", () => {
       const allWatcher = conn?.info.getFacade?.("allWatcher") as AllWatcherV0;
       const watcherId = 42;
       allWatcher?.next(watcherId, (err) => {
-        expect(err).toBe("bad wolf");
+        expect(err).toStrictEqual(new Error("bad wolf"));
       });
       // Reply to the next request.
       ws.reply({ error: "bad wolf" });
@@ -171,7 +183,7 @@ describe("wrapAllWatcher", () => {
     makeConnection(options, (conn, ws) => {
       const allWatcher = conn?.info.getFacade?.("allWatcher") as AllWatcherV0;
       const watcherId = 42;
-      allWatcher.stop(watcherId, (result) => {
+      allWatcher.stop(watcherId, (_error, result) => {
         requestEqual(ws.lastRequest, {
           type: "AllWatcher",
           request: "Stop",
@@ -191,7 +203,7 @@ describe("wrapAllWatcher", () => {
       const allWatcher = conn?.info.getFacade?.("allWatcher") as AllWatcherV0;
       const watcherId = 42;
       allWatcher.stop(watcherId, (err) => {
-        expect(err).toBe("bad wolf");
+        expect(err).toStrictEqual(new Error("bad wolf"));
       });
       // Reply to the next request.
       ws.reply({ error: "bad wolf" });
@@ -225,7 +237,7 @@ describe("wrapClient", () => {
     makeConnection(options, (conn, ws) => {
       const client = conn?.info.getFacade?.("client") as ClientV3;
       let callCount = 0;
-      client?.watch((result) => {
+      client?.watch((_error, result) => {
         callCount += 1;
         switch (callCount) {
           case 1:
@@ -275,7 +287,9 @@ describe("wrapClient", () => {
     makeConnection(options, (conn, ws) => {
       const client = conn?.info.getFacade?.("client") as ClientV3;
       client.watch((err) => {
-        expect(err).toBe("watch requires the allWatcher facade to be loaded");
+        expect(err).toStrictEqual(
+          new Error("watch requires the allWatcher facade to be loaded")
+        );
         // Only the login request has been made, no other requests.
         expect(ws.requests.length).toBe(1);
       });
@@ -288,10 +302,10 @@ describe("wrapClient", () => {
       static NAME = "Client";
       static VERSION = 3;
       watchAll(callback: Callback<Record<string, number>>) {
-        callback("bad wolf", {});
+        callback(new Error("bad wolf"), {});
       }
       watch(callback: Callback<Record<string, number>>) {
-        callback("bad wolf", {});
+        callback(new Error("bad wolf"), {});
       }
     }
     class AllWatcherV0 extends BaseFacade {
@@ -305,7 +319,7 @@ describe("wrapClient", () => {
     makeConnection(options, (conn, _ws) => {
       const client = conn?.info.getFacade?.("client") as ClientV3;
       client.watch((err) => {
-        expect(err).toBe("bad wolf");
+        expect(err).toStrictEqual(new Error("bad wolf"));
       });
       done();
     });
@@ -333,7 +347,7 @@ describe("wrapClient", () => {
     makeConnection(options, (conn, ws) => {
       const client = conn?.info.getFacade?.("client") as ClientV3;
       client.watch((err) => {
-        expect(err).toBe("bad wolf");
+        expect(err).toStrictEqual(new Error("bad wolf"));
       });
       // Reply to the next request.
       ws.reply({ error: "bad wolf" });
@@ -417,7 +431,7 @@ describe("wrapClient", () => {
       static NAME = "Client";
       static VERSION = 3;
       addMachines(args: unknown, callback: Callback<Record<string, void>>) {
-        callback("bad wolf", {});
+        callback(new Error("bad wolf"), {});
       }
     }
     const options = {
@@ -427,7 +441,7 @@ describe("wrapClient", () => {
     makeConnection(options, (conn, _ws) => {
       const client = conn?.info.getFacade?.("client") as ClientV3;
       client.addMachines({ series: "bionic" }, (err) => {
-        expect(err).toBe("bad wolf");
+        expect(err).toStrictEqual(new Error("bad wolf"));
       });
       done();
     });
@@ -460,7 +474,7 @@ describe("wrapController", () => {
     makeConnection(options, (conn, ws) => {
       const controller = conn?.info.getFacade?.("controller") as ControllerV4;
       let callCount = 0;
-      controller?.watch((result) => {
+      controller?.watch((_error, result) => {
         callCount += 1;
         switch (callCount) {
           case 1:
@@ -510,8 +524,8 @@ describe("wrapController", () => {
     makeConnection(options, (conn, ws) => {
       const controller = conn?.info.getFacade?.("controller") as ControllerV4;
       controller.watch((err) => {
-        expect(err).toBe(
-          "watch requires the allModelWatcher facade to be loaded"
+        expect(err).toStrictEqual(
+          new Error("watch requires the allModelWatcher facade to be loaded")
         );
         // Only the login request has been made, no other requests.
         expect(ws.requests.length).toBe(1);
@@ -525,10 +539,10 @@ describe("wrapController", () => {
       static NAME = "Controller";
       static VERSION = 4;
       watchAllModels(callback: Callback<Record<string, number>>) {
-        callback("bad wolf", {});
+        callback(new Error("bad wolf"), {});
       }
       watch(callback: Callback<Record<string, number>>) {
-        callback("bad wolf", {});
+        callback(new Error("bad wolf"), {});
       }
     }
     class AllModelWatcherV1 extends BaseFacade {
@@ -545,7 +559,7 @@ describe("wrapController", () => {
     makeConnection(options, (conn, _ws) => {
       const controller = conn?.info.getFacade?.("controller") as ControllerV4;
       controller.watch((err) => {
-        expect(err).toBe("bad wolf");
+        expect(err).toStrictEqual(new Error("bad wolf"));
       });
       done();
     });
@@ -576,7 +590,7 @@ describe("wrapController", () => {
     makeConnection(options, (conn, ws) => {
       const controller = conn?.info.getFacade?.("controller") as ControllerV5;
       controller.watch((err) => {
-        expect(err).toBe("bad wolf");
+        expect(err).toStrictEqual(new Error("bad wolf"));
       });
       // Reply to the next request.
       ws.reply({ error: "bad wolf" });

--- a/api/utils.ts
+++ b/api/utils.ts
@@ -36,15 +36,19 @@ export function createAsyncHandler<T>(
   resolve: (value: T) => void,
   reject: (value: CallbackError) => void,
   transform?: (value: T) => T
-): Callback<T> {
-  return (err, value) => {
-    if (err) {
-      callback ? callback(err) : reject(err);
-      return;
-    }
-    if (transform) {
-      value = transform(value!);
-    }
-    callback ? callback(null, value) : resolve(value!);
+): { resolve: Function; reject: Function } {
+  return {
+    resolve: (value: T) => {
+      if (transform) {
+        value = transform(value!);
+      }
+      callback ? callback(null, value) : resolve(value!);
+    },
+    reject: (error: CallbackError) => {
+      if (error) {
+        callback ? callback(error) : reject(error);
+        return;
+      }
+    },
   };
 }

--- a/api/utils.ts
+++ b/api/utils.ts
@@ -3,6 +3,10 @@
 
 import { Callback, CallbackError } from "../generator/interfaces";
 
+export enum Label {
+  UNKNOWN_ERROR = "Unknown error",
+}
+
 /**
   Automatically bind all methods of the given object to the object itself.
   @param obj The object whose method must be bound.
@@ -51,4 +55,20 @@ export function createAsyncHandler<T>(
       }
     },
   };
+}
+
+/**
+  Convert given input to an Error object.
+
+  @param error - The input to be converted to an Error object.
+  @returns An Error object.
+*/
+export function toError(error: any): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  if (typeof error === "string") {
+    return new Error(error);
+  }
+  return new Error(Label.UNKNOWN_ERROR);
 }

--- a/api/utils.ts
+++ b/api/utils.ts
@@ -38,9 +38,9 @@ export function autoBind(obj: { [k: string]: any }): void {
 export function createAsyncHandler<T>(
   callback: Callback<T> | undefined,
   resolve: (value: T) => void,
-  reject: (value: CallbackError) => void,
+  reject: (error: CallbackError) => void,
   transform?: (value: T) => T
-): { resolve: Function; reject: Function } {
+): { resolve: (value: T) => void; reject: (error: CallbackError) => void } {
   return {
     resolve: (value: T) => {
       if (transform) {
@@ -48,9 +48,7 @@ export function createAsyncHandler<T>(
       }
       callback ? callback(null, value) : resolve(value!);
     },
-    reject: (error: CallbackError) => {
-      callback ? callback(error) : reject(error);
-    },
+    reject: callback ? callback : reject,
   };
 }
 

--- a/api/utils.ts
+++ b/api/utils.ts
@@ -49,10 +49,7 @@ export function createAsyncHandler<T>(
       callback ? callback(null, value) : resolve(value!);
     },
     reject: (error: CallbackError) => {
-      if (error) {
-        callback ? callback(error) : reject(error);
-        return;
-      }
+      callback ? callback(error) : reject(error);
     },
   };
 }

--- a/generator/interfaces.ts
+++ b/generator/interfaces.ts
@@ -55,5 +55,6 @@ export interface JujuRequest {
   [key: string]: any; // Some calls pass additional params e.g. AllWatcher.next passes `id`.
 }
 
-export type CallbackError = string | number | null;
-export type Callback<T> = (error?: CallbackError, value?: T) => void;
+export type CallbackError = Error | null;
+export type Callback<T> = (error: CallbackError, value?: T) => void;
+// check that we need to put null in front if there is value

--- a/generator/interfaces.ts
+++ b/generator/interfaces.ts
@@ -57,3 +57,4 @@ export interface JujuRequest {
 
 export type CallbackError = Error | null;
 export type Callback<T> = (error: CallbackError, value?: T) => void;
+export type CloseCallback = (code: number) => void;

--- a/generator/interfaces.ts
+++ b/generator/interfaces.ts
@@ -57,4 +57,3 @@ export interface JujuRequest {
 
 export type CallbackError = Error | null;
 export type Callback<T> = (error: CallbackError, value?: T) => void;
-// check that we need to put null in front if there is value

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/jujulib",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Juju API client",
   "main": "dist/api/client.js",
   "types": "dist/api/client.d.ts",


### PR DESCRIPTION
## Done
- Use callback resolve/reject for error/successful request in `Transport` instead of resolving with `string` for error and resolving with other type for successful request.

## Details
- https://warthogs.atlassian.net/browse/WD-9334