### PR TITLE
chore(package): fix the version bump to 8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/jujulib",
-  "version": "8.1.1",
+  "version": "8.1.0",
   "description": "Juju API client",
   "main": "dist/api/client.js",
   "types": "dist/api/client.d.ts",


### PR DESCRIPTION
Accidentally included the old patch number in the version bump (went from 8.0.1 -> 8.1.1 instead of 8.1.0).