### PR TITLE
chore: bump checkout to v6 and update CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "yarn"
       - name: Install
         run: yarn install --immutable
       - run: yarn test
@@ -36,6 +37,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "yarn"
       - name: Install
         run: yarn install --immutable
       - run: yarn prettier --check 'api/**/*'
@@ -52,6 +54,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "yarn"
       - name: Install
         run: yarn install --immutable
       - run: yarn lint
@@ -68,6 +71,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "yarn"
       - name: Install
         run: yarn install --immutable
       - run: CI=false yarn build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,11 @@ jobs:
         node-version: [22.x]
     steps:
       - run: corepack enable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "yarn"
       - name: Install
         run: yarn install --immutable
       - run: yarn test
@@ -32,12 +31,11 @@ jobs:
         node-version: [22.x]
     steps:
       - run: corepack enable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "yarn"
       - name: Install
         run: yarn install --immutable
       - run: yarn prettier --check 'api/**/*'
@@ -49,12 +47,11 @@ jobs:
         node-version: [22.x]
     steps:
       - run: corepack enable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "yarn"
       - name: Install
         run: yarn install --immutable
       - run: yarn lint
@@ -66,12 +63,11 @@ jobs:
         node-version: [22.x]
     steps:
       - run: corepack enable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "yarn"
       - name: Install
         run: yarn install --immutable
       - run: CI=false yarn build

--- a/.github/workflows/github-io-docs.yml
+++ b/.github/workflows/github-io-docs.yml
@@ -10,14 +10,15 @@ jobs:
       matrix:
         node-version: [22.x]
     steps:
+      - run: corepack enable
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-      - run: corepack enable
+          cache: "yarn"
       - name: Install Dependencies
-        run: yarn install --immutable
+        run: yarn install
       - name: Build the project
         run: yarn build
       - name: Generate Docs

--- a/.github/workflows/github-io-docs.yml
+++ b/.github/workflows/github-io-docs.yml
@@ -6,10 +6,18 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: corepack enable
       - name: Install Dependencies
-        run: yarn install
+        run: yarn install --immutable
       - name: Build the project
         run: yarn build
       - name: Generate Docs


### PR DESCRIPTION
- Bumped `actions/checkout` from v3 to v6
- Added missing Node.js setup to `github-io-docs.yml`

### Details 
The `packageManager` field in `package.json` requires Corepack to be enabled before running Yarn commands. CI was failing because it was relying on a bare `corepack enable` step before `actions/checkout`, and the `github-io-docs` workflow was missing Node.js setup entirely. See [this](https://github.com/juju/js-libjuju/actions/runs/28769769968/job/85301006719).